### PR TITLE
Add DXT normalizer with request validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Core delivery platform Node.js Backend Template.
 - [Postman Collection](#postman-collection)
   - [Getting Started](#getting-started)
   - [Usage](#usage)
+    - [Dynamic Request Body Handling](#dynamic-request-body-handling)
   - [Keeping the Collection Updated](#keeping-the-collection-updated)
   - [Example Folder Structure](#example-folder-structure)
 - [Licence](#licence)
@@ -191,6 +192,93 @@ The project includes a Postman collection to make it easier to test and interact
 
 - **Add Authorization**:
   If the API requires authentication (e.g., API keys or tokens), configure it under the **Authorization** tab for each request or in the environment variables.
+
+### Dynamic Request Body Handling
+
+This script dynamically selects the appropriate request body based on the **grant type** and whether the **DXT Normalizer** is enabled. It helps simplify testing different request payloads without manually switching them.
+
+#### 📦 **Script Logic**
+
+```javascript
+const grantType = pm.environment.get('grantType')
+const isDxtNormaliserEnabled =
+  pm.environment.get('isDxtNormaliserEnabled') === 'true'
+
+// Determine which body to use
+const bodyKey = isDxtNormaliserEnabled
+  ? `grant_${grantType}_body_dxt`
+  : `grant_${grantType}_body`
+
+// Fetch the body from environment variables
+const body = pm.environment.get(bodyKey)
+
+// Set dynamic_body or show an error if missing
+if (!body) {
+  console.error(`Error: ${bodyKey} is not defined in the environment.`)
+} else {
+  pm.variables.set('dynamic_body', body)
+  console.log(`Dynamic body set for ${bodyKey}`)
+}
+```
+
+#### ⚙️ **Environment Variable Setup**
+
+| Variable                     | Example Value     | Description                       |
+| ---------------------------- | ----------------- | --------------------------------- |
+| `grantType`                  | `agriculture`     | The grant type you're testing.    |
+| `isDxtNormaliserEnabled`     | `true` or `false` | Enables DXT format when `true`.   |
+| `grant_agriculture_body`     | `{...}`           | Standard body for the grant.      |
+| `grant_agriculture_body_dxt` | `{...}`           | DXT-formatted body for the grant. |
+
+1. Go to **Manage Environments (⚙️)** → **Edit Environment**.
+2. Add the above key-value pairs.
+3. Make sure `isDxtNormaliserEnabled` is a **string** (`"true"` or `"false"`) rather than a boolean.
+
+#### 📝 **Using the Dynamic Body in Requests**
+
+In the request body:
+
+```json
+{{dynamic_body}}
+```
+
+#### ✅ **Example**
+
+**Environment Setup:**
+
+```bash
+grantType = agriculture
+isDxtNormaliserEnabled = true
+grant_agriculture_body = { "answers": [{"key": "value"}] }
+grant_agriculture_body_dxt = { "data": { "main": { "key": "value" } } }
+```
+
+**When `isDxtNormaliserEnabled = true`:**
+
+```json
+{
+  "data": {
+    "main": {
+      "key": "value"
+    }
+  }
+}
+```
+
+**When `isDxtNormaliserEnabled = false`:**
+
+```json
+{
+  "answers": [{ "key": "value" }]
+}
+```
+
+#### 🚩 **Troubleshooting**
+
+- **Error:** `Error: grant_agriculture_body_dxt is not defined in the environment.`
+  - **Fix:** Ensure the `grant_agriculture_body_dxt` variable is set in the environment.
+- **Incorrect Body?**
+  - Confirm that `isDxtNormaliserEnabled` is a **string**, not a boolean.
 
 ### Keeping the Collection Updated
 

--- a/postman/ffc-grants-scoring.dev.postman_environment.json
+++ b/postman/ffc-grants-scoring.dev.postman_environment.json
@@ -34,18 +34,18 @@
 		},
 		{
 			"key": "grant_example-grant_body_dxt",
-			"value": "{\n  \"data\": {\n    \"singleAnswer\": [\"B\"],\n    \"multiAnswer\": [\"A\", \"B\"]\n  }\n}\n",
+			"value": "{\n  \"data\": {\n    \"main: {\n      \"singleAnswer\": [\"B\"],\n      \"multiAnswer\": [\"A\", \"B\"]\n    }\n  }\n}\n",
 			"type": "default",
 			"enabled": true
 		},
 		{
 			"key": "grant_adding-value_body_dxt",
-			"value": "{\n  \"data\": {\n    \"/products-processed\": [\"products-processed-A1\"],\n    \"/adding-value\": [\"adding-value-A1\"],\n    \"/project-impact\": [\"project-impact-A1\"],\n    \"/future-customers\": [\"future-customers-A1\"],\n    \"/collaboration\": [\"collaboration-A1\"],\n    \"/environmental-impact\": [\"environmental-impact-A1\",\"environmental-impact-A2\",\"environmental-impact-A3\"]\n  }\n}\n",
+			"value": "{\n  \"data\": {\n    \"main\": {\n      \"/products-processed\": [\"products-processed-A1\"],\n      \"/adding-value\": [\"adding-value-A1\"],\n      \"/project-impact\": [\"project-impact-A1\"],\n      \"/future-customers\": [\"future-customers-A1\"],\n      \"/collaboration\": [\"collaboration-A1\"],\n      \"/environmental-impact\": [\"environmental-impact-A1\",\"environmental-impact-A2\",\"environmental-impact-A3\"]\n    }\n  }\n}\n",
 			"type": "default",
 			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2025-02-05T13:09:52.482Z",
+	"_postman_exported_at": "2025-02-05T16:54:31.578Z",
 	"_postman_exported_using": "Postman/9.11.0"
 }

--- a/postman/ffc-grants-scoring.dev.postman_environment.json
+++ b/postman/ffc-grants-scoring.dev.postman_environment.json
@@ -15,6 +15,12 @@
 			"enabled": true
 		},
 		{
+			"key": "isDxtNormaliserEnabled",
+			"value": "true",
+			"type": "default",
+			"enabled": true
+		},
+		{
 			"key": "grant_example-grant_body",
 			"value": "{\n  \"answers\": [\n    { \"questionId\": \"singleAnswer\", \"answers\": [\"B\"] },\n    { \"questionId\": \"multiAnswer\", \"answers\": [\"A\", \"B\"] }\n  ]\n}\n",
 			"type": "default",
@@ -25,9 +31,21 @@
 			"value": "{\n  \"answers\": [\n    { \"questionId\": \"/products-processed\", \"answers\": [\"products-processed-A1\"] },\n    { \"questionId\": \"/adding-value\", \"answers\": [\"adding-value-A1\"] },\n    { \"questionId\": \"/project-impact\", \"answers\": [\"project-impact-A1\"] },\n    { \"questionId\": \"/future-customers\", \"answers\": [\"future-customers-A1\"] },\n    { \"questionId\": \"/collaboration\", \"answers\": [\"collaboration-A1\"] },\n    { \"questionId\": \"/environmental-impact\", \"answers\": [\"environmental-impact-A1\",\"environmental-impact-A2\",\"environmental-impact-A3\"] }\n  ]\n}\n",
 			"type": "default",
 			"enabled": true
+		},
+		{
+			"key": "grant_example-grant_body_dxt",
+			"value": "{\n  \"data\": {\n    \"singleAnswer\": [\"B\"],\n    \"multiAnswer\": [\"A\", \"B\"]\n  }\n}\n",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "grant_adding-value_body_dxt",
+			"value": "{\n  \"data\": {\n    \"/products-processed\": [\"products-processed-A1\"],\n    \"/adding-value\": [\"adding-value-A1\"],\n    \"/project-impact\": [\"project-impact-A1\"],\n    \"/future-customers\": [\"future-customers-A1\"],\n    \"/collaboration\": [\"collaboration-A1\"],\n    \"/environmental-impact\": [\"environmental-impact-A1\",\"environmental-impact-A2\",\"environmental-impact-A3\"]\n  }\n}\n",
+			"type": "default",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2025-02-03T20:21:22.433Z",
+	"_postman_exported_at": "2025-02-05T13:09:52.482Z",
 	"_postman_exported_using": "Postman/9.11.0"
 }

--- a/postman/ffc-grants-scoring.dev.postman_environment.json
+++ b/postman/ffc-grants-scoring.dev.postman_environment.json
@@ -34,18 +34,18 @@
 		},
 		{
 			"key": "grant_example-grant_body_dxt",
-			"value": "{\n  \"data\": {\n    \"main: {\n      \"singleAnswer\": [\"B\"],\n      \"multiAnswer\": [\"A\", \"B\"]\n    }\n  }\n}\n",
+			"value": "{\n  \"data\": {\n    \"main: {\n      \"singleAnswer\": \"B\",\n      \"multiAnswer\": [\"A\", \"B\"]\n    }\n  }\n}\n",
 			"type": "default",
 			"enabled": true
 		},
 		{
 			"key": "grant_adding-value_body_dxt",
-			"value": "{\n  \"data\": {\n    \"main\": {\n      \"/products-processed\": [\"products-processed-A1\"],\n      \"/adding-value\": [\"adding-value-A1\"],\n      \"/project-impact\": [\"project-impact-A1\"],\n      \"/future-customers\": [\"future-customers-A1\"],\n      \"/collaboration\": [\"collaboration-A1\"],\n      \"/environmental-impact\": [\"environmental-impact-A1\",\"environmental-impact-A2\",\"environmental-impact-A3\"]\n    }\n  }\n}\n",
+			"value": "{\n  \"data\": {\n    \"main\": {\n      \"/products-processed\": \"products-processed-A1\",\n      \"/adding-value\": \"adding-value-A1\",\n      \"/project-impact\": \"project-impact-A1\",\n      \"/future-customers\": \"future-customers-A1\",\n      \"/collaboration\": \"collaboration-A1\",\n      \"/environmental-impact\": [\"environmental-impact-A1\",\"environmental-impact-A2\",\"environmental-impact-A3\"]\n    }\n  }\n}\n",
 			"type": "default",
 			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2025-02-05T16:54:31.578Z",
+	"_postman_exported_at": "2025-02-05T17:22:02.462Z",
 	"_postman_exported_using": "Postman/9.11.0"
 }

--- a/postman/ffc-grants-scoring.local.postman_environment.json
+++ b/postman/ffc-grants-scoring.local.postman_environment.json
@@ -34,18 +34,18 @@
 		},
 		{
 			"key": "grant_example-grant_body_dxt",
-			"value": "{\n  \"data\": {\n    \"main: {\n      \"singleAnswer\": [\"B\"],\n      \"multiAnswer\": [\"A\", \"B\"]\n    }\n  }\n}\n",
+			"value": "{\n  \"data\": {\n    \"main: {\n      \"singleAnswer\": \"B\",\n      \"multiAnswer\": [\"A\", \"B\"]\n    }\n  }\n}\n",
 			"type": "default",
 			"enabled": true
 		},
 		{
 			"key": "grant_adding-value_body_dxt",
-			"value": "{\n  \"data\": {\n    \"main\": {\n      \"/products-processed\": [\"products-processed-A1\"],\n      \"/adding-value\": [\"adding-value-A1\"],\n      \"/project-impact\": [\"project-impact-A1\"],\n      \"/future-customers\": [\"future-customers-A1\"],\n      \"/collaboration\": [\"collaboration-A1\"],\n      \"/environmental-impact\": [\"environmental-impact-A1\",\"environmental-impact-A2\",\"environmental-impact-A3\"]\n    }\n  }\n}\n",
+			"value": "{\n  \"data\": {\n    \"main\": {\n      \"/products-processed\": \"products-processed-A1\",\n      \"/adding-value\": \"adding-value-A1\",\n      \"/project-impact\": \"project-impact-A1\",\n      \"/future-customers\": \"future-customers-A1\",\n      \"/collaboration\": \"collaboration-A1\",\n      \"/environmental-impact\": [\"environmental-impact-A1\",\"environmental-impact-A2\",\"environmental-impact-A3\"]\n    }\n  }\n}\n",
 			"type": "default",
 			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2025-02-05T16:53:57.516Z",
+	"_postman_exported_at": "2025-02-05T17:21:43.125Z",
 	"_postman_exported_using": "Postman/9.11.0"
 }

--- a/postman/ffc-grants-scoring.local.postman_environment.json
+++ b/postman/ffc-grants-scoring.local.postman_environment.json
@@ -34,18 +34,18 @@
 		},
 		{
 			"key": "grant_example-grant_body_dxt",
-			"value": "{\n  \"data\": {\n    \"singleAnswer\": [\"B\"],\n    \"multiAnswer\": [\"A\", \"B\"]\n  }\n}\n",
+			"value": "{\n  \"data\": {\n    \"main: {\n      \"singleAnswer\": [\"B\"],\n      \"multiAnswer\": [\"A\", \"B\"]\n    }\n  }\n}\n",
 			"type": "default",
 			"enabled": true
 		},
 		{
 			"key": "grant_adding-value_body_dxt",
-			"value": "{\n  \"data\": {\n    \"/products-processed\": [\"products-processed-A1\"],\n    \"/adding-value\": [\"adding-value-A1\"],\n    \"/project-impact\": [\"project-impact-A1\"],\n    \"/future-customers\": [\"future-customers-A1\"],\n    \"/collaboration\": [\"collaboration-A1\"],\n    \"/environmental-impact\": [\"environmental-impact-A1\",\"environmental-impact-A2\",\"environmental-impact-A3\"]\n  }\n}\n",
+			"value": "{\n  \"data\": {\n    \"main\": {\n      \"/products-processed\": [\"products-processed-A1\"],\n      \"/adding-value\": [\"adding-value-A1\"],\n      \"/project-impact\": [\"project-impact-A1\"],\n      \"/future-customers\": [\"future-customers-A1\"],\n      \"/collaboration\": [\"collaboration-A1\"],\n      \"/environmental-impact\": [\"environmental-impact-A1\",\"environmental-impact-A2\",\"environmental-impact-A3\"]\n    }\n  }\n}\n",
 			"type": "default",
 			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2025-02-05T13:09:31.305Z",
+	"_postman_exported_at": "2025-02-05T16:53:57.516Z",
 	"_postman_exported_using": "Postman/9.11.0"
 }

--- a/postman/ffc-grants-scoring.local.postman_environment.json
+++ b/postman/ffc-grants-scoring.local.postman_environment.json
@@ -15,6 +15,12 @@
 			"enabled": true
 		},
 		{
+			"key": "isDxtNormaliserEnabled",
+			"value": "true",
+			"type": "default",
+			"enabled": true
+		},
+		{
 			"key": "grant_example-grant_body",
 			"value": "{\n  \"answers\": [\n    { \"questionId\": \"singleAnswer\", \"answers\": [\"B\"] },\n    { \"questionId\": \"multiAnswer\", \"answers\": [\"A\", \"B\"] }\n  ]\n}\n",
 			"type": "default",
@@ -25,9 +31,21 @@
 			"value": "{\n  \"answers\": [\n    { \"questionId\": \"/products-processed\", \"answers\": [\"products-processed-A1\"] },\n    { \"questionId\": \"/adding-value\", \"answers\": [\"adding-value-A1\"] },\n    { \"questionId\": \"/project-impact\", \"answers\": [\"project-impact-A1\"] },\n    { \"questionId\": \"/future-customers\", \"answers\": [\"future-customers-A1\"] },\n    { \"questionId\": \"/collaboration\", \"answers\": [\"collaboration-A1\"] },\n    { \"questionId\": \"/environmental-impact\", \"answers\": [\"environmental-impact-A1\",\"environmental-impact-A2\",\"environmental-impact-A3\"] }\n  ]\n}\n",
 			"type": "default",
 			"enabled": true
+		},
+		{
+			"key": "grant_example-grant_body_dxt",
+			"value": "{\n  \"data\": {\n    \"singleAnswer\": [\"B\"],\n    \"multiAnswer\": [\"A\", \"B\"]\n  }\n}\n",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "grant_adding-value_body_dxt",
+			"value": "{\n  \"data\": {\n    \"/products-processed\": [\"products-processed-A1\"],\n    \"/adding-value\": [\"adding-value-A1\"],\n    \"/project-impact\": [\"project-impact-A1\"],\n    \"/future-customers\": [\"future-customers-A1\"],\n    \"/collaboration\": [\"collaboration-A1\"],\n    \"/environmental-impact\": [\"environmental-impact-A1\",\"environmental-impact-A2\",\"environmental-impact-A3\"]\n  }\n}\n",
+			"type": "default",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2025-02-03T20:20:33.176Z",
+	"_postman_exported_at": "2025-02-05T13:09:31.305Z",
 	"_postman_exported_using": "Postman/9.11.0"
 }

--- a/postman/ffc-grants-scoring.postman_collection.json
+++ b/postman/ffc-grants-scoring.postman_collection.json
@@ -49,100 +49,7 @@
 					]
 				}
 			},
-			"response": [
-				{
-					"name": "Evaluate Grant Eligibility - example grant",
-					"originalRequest": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Accept",
-								"value": "\"application/json, text/plain, */*\"",
-								"type": "default",
-								"disabled": true
-							},
-							{
-								"key": "Content-Type",
-								"value": "\"application/json\"",
-								"type": "default",
-								"disabled": true
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"answers\": [\n    { \"questionId\": \"singleAnswer\", \"answers\": [\"B\"] },\n    { \"questionId\": \"multiAnswer\", \"answers\": [\"A\", \"B\"] }\n  ]\n}\n",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{base_url}}/scoring/api/v1/{{grantType}}/score",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"scoring",
-								"api",
-								"v1",
-								"{{grantType}}",
-								"score"
-							]
-						}
-					},
-					"_postman_previewlanguage": null,
-					"header": null,
-					"cookie": [],
-					"body": null
-				},
-				{
-					"name": "Evaluate Grant Eligibility - adding value",
-					"originalRequest": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Accept",
-								"value": "\"application/json, text/plain, */*\"",
-								"type": "default",
-								"disabled": true
-							},
-							{
-								"key": "Content-Type",
-								"value": "\"application/json\"",
-								"type": "default",
-								"disabled": true
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"answers\": [\n    { \"questionId\": \"singleAnswer\", \"answers\": [\"B\"] },\n    { \"questionId\": \"multiAnswer\", \"answers\": [\"A\", \"B\"] }\n  ]\n}\n",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{base_url}}/scoring/api/v1/{{grantType}}/score",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"scoring",
-								"api",
-								"v1",
-								"{{grantType}}",
-								"score"
-							]
-						}
-					},
-					"_postman_previewlanguage": null,
-					"header": null,
-					"cookie": [],
-					"body": null
-				}
-			]
+			"response": []
 		},
 		{
 			"name": "Health",
@@ -185,8 +92,23 @@
 				"type": "text/javascript",
 				"exec": [
 					"const grantType = pm.environment.get(\"grantType\");",
-					"const body = pm.environment.get(`grant_${grantType}_body`);",
-					"pm.variables.set(\"dynamic_body\", body);",
+					"console.log(`Boolean(pm.environment.get(\"isDxtNormaliserEnabled\"))=${pm.environment.get(\"isDxtNormaliserEnabled\")}`)",
+					"console.log(`Boolean(pm.environment.get(\"isDxtNormaliserEnabled\"))===\"true\" = ${pm.environment.get(\"isDxtNormaliserEnabled\")===\"true\"}`)",
+					"const isDxtNormaliserEnabled = pm.environment.get(\"isDxtNormaliserEnabled\") === \"true\";",
+					"console.log(`isDxtNormaliserEnabled=${isDxtNormaliserEnabled}`)",
+					"",
+					"// Retrieve the dynamic body based on grantType and hasDxtNormaliser flag",
+					"const bodyKey = isDxtNormaliserEnabled ? `grant_${grantType}_body_dxt` : `grant_${grantType}_body`;",
+					"",
+					"// Ensure the environment variable exists",
+					"const body = pm.environment.get(bodyKey);",
+					"",
+					"if (!body) {",
+					"    console.error(`Error: ${bodyKey} is not defined in the environment.`);",
+					"} else {",
+					"    pm.variables.set(\"dynamic_body\", body);",
+					"    console.log(`Dynamic body set for ${bodyKey}`);",
+					"}",
 					""
 				]
 			}

--- a/src/api/scoring/dxt-normaliser.js
+++ b/src/api/scoring/dxt-normaliser.js
@@ -44,14 +44,17 @@ export const normalizePayload = (request, h) => {
   const { data } = request.payload
 
   if (data?.main) {
-    request.payload.answers = Object.entries(data.main).map(([key, value]) => ({
-      questionId: key,
-      answers: Array.isArray(value)
-        ? value
-        : value != null
-          ? [value] // Wrap string, number, or boolean in an array
-          : [] // Fallback to an empty array if value is null/undefined
-    }))
+    request.payload.answers = Object.entries(data.main).map(([key, value]) => {
+      let answers = []
+
+      if (Array.isArray(value)) {
+        answers = value
+      } else if (value != null) {
+        answers = [value] // Wrap string, number, or boolean in an array
+      }
+
+      return { questionId: key, answers }
+    })
     delete request.payload.data
   }
 

--- a/src/api/scoring/dxt-normaliser.js
+++ b/src/api/scoring/dxt-normaliser.js
@@ -2,15 +2,17 @@
  * Pre-handler to normalize incoming request payloads to a unified `answers` format.
  *
  * This function supports two payload formats:
- * 1. **Key-Value Format** (`data`): Transforms `{ data: { key: value } }` into the `answers` array format.
+ * 1. **Key-Value Format** (`data.main`): Transforms `{ data: { main: { key: value } } }` into the `answers` array format.
  * 2. **Answers Format** (`answers`): If the payload already has `answers`, it remains unchanged.
  *
  * **Before (Key-Value Format):**
  * ```json
  * {
  *   "data": {
- *     "component1Name": "component1Value",
- *     "component2Name": "component2Value"
+ *     "main": {
+ *       "component1Name": "component1Value",
+ *       "component2Name": "component2Value"
+ *     }
  *   }
  * }
  * ```
@@ -41,13 +43,12 @@
 export const normalizePayload = (request, h) => {
   const { data } = request.payload
 
-  // If data exists, translate it to the "answers" format
-  if (data) {
-    request.payload.answers = Object.entries(data).map(([key, value]) => ({
+  if (data?.main) {
+    request.payload.answers = Object.entries(data.main).map(([key, value]) => ({
       questionId: key,
       answers: value
     }))
-    delete request.payload.data // Remove the original data property
+    delete request.payload.data
   }
 
   return h.continue

--- a/src/api/scoring/dxt-normaliser.js
+++ b/src/api/scoring/dxt-normaliser.js
@@ -46,7 +46,11 @@ export const normalizePayload = (request, h) => {
   if (data?.main) {
     request.payload.answers = Object.entries(data.main).map(([key, value]) => ({
       questionId: key,
-      answers: value
+      answers: Array.isArray(value)
+        ? value
+        : value != null
+          ? [value] // Wrap string, number, or boolean in an array
+          : [] // Fallback to an empty array if value is null/undefined
     }))
     delete request.payload.data
   }

--- a/src/api/scoring/dxt-normaliser.js
+++ b/src/api/scoring/dxt-normaliser.js
@@ -51,6 +51,9 @@ export const normalizePayload = (request, h) => {
         answers = value
       } else if (value != null) {
         answers = [value] // Wrap string, number, or boolean in an array
+      } else {
+        // This handles cases where value is null or undefined.
+        answers = []
       }
 
       return { questionId: key, answers }

--- a/src/api/scoring/dxt-normaliser.js
+++ b/src/api/scoring/dxt-normaliser.js
@@ -1,0 +1,54 @@
+/**
+ * Pre-handler to normalize incoming request payloads to a unified `answers` format.
+ *
+ * This function supports two payload formats:
+ * 1. **Key-Value Format** (`data`): Transforms `{ data: { key: value } }` into the `answers` array format.
+ * 2. **Answers Format** (`answers`): If the payload already has `answers`, it remains unchanged.
+ *
+ * **Before (Key-Value Format):**
+ * ```json
+ * {
+ *   "data": {
+ *     "component1Name": "component1Value",
+ *     "component2Name": "component2Value"
+ *   }
+ * }
+ * ```
+ *
+ * **After Transformation:**
+ * ```json
+ * {
+ *   "answers": [
+ *     { "questionId": "component1Name", "answers": ["component1Value"] },
+ *     { "questionId": "component2Name", "answers": ["component2Value"] }
+ *   ]
+ * }
+ * ```
+ *
+ * **If Payload is Already in `answers` Format:**
+ * ```json
+ * {
+ *   "answers": [
+ *     { "questionId": "component1Name", "answers": ["component1Value"] }
+ *   ]
+ * }
+ * ```
+ * This format is passed through without changes.
+ * @param {object} request - The Hapi request object containing the payload.
+ * @param {object} h - The Hapi response toolkit to continue the lifecycle.
+ * @returns {object} `h.continue` to proceed to the next lifecycle step.
+ */
+export const normalizePayload = (request, h) => {
+  const { data } = request.payload
+
+  // If data exists, translate it to the "answers" format
+  if (data) {
+    request.payload.answers = Object.entries(data).map(([key, value]) => ({
+      questionId: key,
+      answers: value
+    }))
+    delete request.payload.data // Remove the original data property
+  }
+
+  return h.continue
+}

--- a/src/api/scoring/dxt-normaliser.test.js
+++ b/src/api/scoring/dxt-normaliser.test.js
@@ -10,8 +10,10 @@ describe('normalizePayload', () => {
     const request = {
       payload: {
         data: {
-          component1Name: ['component1Value'],
-          component2Name: ['component2Value']
+          main: {
+            component1Name: ['component1Value'],
+            component2Name: ['component2Value']
+          }
         }
       }
     }
@@ -31,11 +33,13 @@ describe('normalizePayload', () => {
     expect(result).toBe(h.continue)
   })
 
-  it('should handle string values', () => {
+  it('should handle string values inside data.main', () => {
     const request = {
       payload: {
         data: {
-          component1Name: 'component1Value'
+          main: {
+            component1Name: 'component1Value'
+          }
         }
       }
     }
@@ -46,11 +50,13 @@ describe('normalizePayload', () => {
     expect(response).toBe(h.continue)
   })
 
-  it('should handle number values', () => {
+  it('should handle number values inside data.main', () => {
     const request = {
       payload: {
         data: {
-          component1Name: 42
+          main: {
+            component1Name: 42
+          }
         }
       }
     }
@@ -61,11 +67,13 @@ describe('normalizePayload', () => {
     expect(response).toBe(h.continue)
   })
 
-  it('should handle string array values', () => {
+  it('should handle string array values inside data.main', () => {
     const request = {
       payload: {
         data: {
-          component1Name: ['value1', 'value2']
+          main: {
+            component1Name: ['value1', 'value2']
+          }
         }
       }
     }
@@ -76,11 +84,13 @@ describe('normalizePayload', () => {
     expect(response).toBe(h.continue)
   })
 
-  it('should handle number array values', () => {
+  it('should handle number array values inside data.main', () => {
     const request = {
       payload: {
         data: {
-          component1Name: [1, 2, 3]
+          main: {
+            component1Name: [1, 2, 3]
+          }
         }
       }
     }
@@ -91,11 +101,13 @@ describe('normalizePayload', () => {
     expect(response).toBe(h.continue)
   })
 
-  it('should handle null values', () => {
+  it('should handle null values inside data.main', () => {
     const request = {
       payload: {
         data: {
-          component1Name: null
+          main: {
+            component1Name: null
+          }
         }
       }
     }
@@ -148,7 +160,9 @@ describe('normalizePayload', () => {
     const request = {
       payload: {
         data: {
-          component1Name: ['component1Value']
+          main: {
+            component1Name: ['component1Value']
+          }
         },
         answers: [
           { questionId: 'component2Name', answers: ['component2Value'] }
@@ -164,6 +178,25 @@ describe('normalizePayload', () => {
     ])
 
     expect(request.payload.data).toBeUndefined()
+
+    // Check that the function proceeds with the lifecycle
+    expect(result).toBe(h.continue)
+  })
+
+  it('should ignore payloads without data.main', () => {
+    const request = {
+      payload: {
+        data: {
+          other: { component1Name: 'value1' }
+        }
+      }
+    }
+    const result = normalizePayload(request, h)
+    expect(request.payload).toEqual({
+      data: {
+        other: { component1Name: 'value1' }
+      }
+    })
 
     // Check that the function proceeds with the lifecycle
     expect(result).toBe(h.continue)

--- a/src/api/scoring/dxt-normaliser.test.js
+++ b/src/api/scoring/dxt-normaliser.test.js
@@ -31,6 +31,81 @@ describe('normalizePayload', () => {
     expect(result).toBe(h.continue)
   })
 
+  it('should handle string values', () => {
+    const request = {
+      payload: {
+        data: {
+          component1Name: 'component1Value'
+        }
+      }
+    }
+    const response = normalizePayload(request, h)
+    expect(request.payload.answers).toEqual([
+      { questionId: 'component1Name', answers: 'component1Value' }
+    ])
+    expect(response).toBe(h.continue)
+  })
+
+  it('should handle number values', () => {
+    const request = {
+      payload: {
+        data: {
+          component1Name: 42
+        }
+      }
+    }
+    const response = normalizePayload(request, h)
+    expect(request.payload.answers).toEqual([
+      { questionId: 'component1Name', answers: 42 }
+    ])
+    expect(response).toBe(h.continue)
+  })
+
+  it('should handle string array values', () => {
+    const request = {
+      payload: {
+        data: {
+          component1Name: ['value1', 'value2']
+        }
+      }
+    }
+    const response = normalizePayload(request, h)
+    expect(request.payload.answers).toEqual([
+      { questionId: 'component1Name', answers: ['value1', 'value2'] }
+    ])
+    expect(response).toBe(h.continue)
+  })
+
+  it('should handle number array values', () => {
+    const request = {
+      payload: {
+        data: {
+          component1Name: [1, 2, 3]
+        }
+      }
+    }
+    const response = normalizePayload(request, h)
+    expect(request.payload.answers).toEqual([
+      { questionId: 'component1Name', answers: [1, 2, 3] }
+    ])
+    expect(response).toBe(h.continue)
+  })
+
+  it('should handle null values', () => {
+    const request = {
+      payload: {
+        data: {
+          component1Name: null
+        }
+      }
+    }
+    const response = normalizePayload(request, h)
+    expect(request.payload.answers).toEqual([
+      { questionId: 'component1Name', answers: null }
+    ])
+    expect(response).toBe(h.continue)
+  })
+
   it('should leave answers format unchanged if it is already in answers format', () => {
     const request = {
       payload: {

--- a/src/api/scoring/dxt-normaliser.test.js
+++ b/src/api/scoring/dxt-normaliser.test.js
@@ -45,7 +45,7 @@ describe('normalizePayload', () => {
     }
     const response = normalizePayload(request, h)
     expect(request.payload.answers).toEqual([
-      { questionId: 'component1Name', answers: 'component1Value' }
+      { questionId: 'component1Name', answers: ['component1Value'] }
     ])
     expect(response).toBe(h.continue)
   })
@@ -62,7 +62,7 @@ describe('normalizePayload', () => {
     }
     const response = normalizePayload(request, h)
     expect(request.payload.answers).toEqual([
-      { questionId: 'component1Name', answers: 42 }
+      { questionId: 'component1Name', answers: [42] }
     ])
     expect(response).toBe(h.continue)
   })
@@ -113,8 +113,38 @@ describe('normalizePayload', () => {
     }
     const response = normalizePayload(request, h)
     expect(request.payload.answers).toEqual([
-      { questionId: 'component1Name', answers: null }
+      { questionId: 'component1Name', answers: [] }
     ])
+    expect(response).toBe(h.continue)
+  })
+
+  it('should handle undefined values inside data.main', () => {
+    const request = {
+      payload: {
+        data: {
+          main: {
+            component1Name: undefined
+          }
+        }
+      }
+    }
+    const response = normalizePayload(request, h)
+    expect(request.payload.answers).toEqual([
+      { questionId: 'component1Name', answers: [] }
+    ])
+    expect(response).toBe(h.continue)
+  })
+
+  it('should handle empty data.main', () => {
+    const request = {
+      payload: {
+        data: {
+          main: {}
+        }
+      }
+    }
+    const response = normalizePayload(request, h)
+    expect(request.payload.answers).toEqual([])
     expect(response).toBe(h.continue)
   })
 

--- a/src/api/scoring/dxt-normaliser.test.js
+++ b/src/api/scoring/dxt-normaliser.test.js
@@ -1,0 +1,96 @@
+import { normalizePayload } from './dxt-normaliser.js' // Adjust the import based on your file structure
+
+describe('normalizePayload', () => {
+  // Mock Hapi response toolkit for testing
+  const h = {
+    continue: 'continue'
+  }
+
+  it('should transform Key-Value format (data) into answers format', () => {
+    const request = {
+      payload: {
+        data: {
+          component1Name: ['component1Value'],
+          component2Name: ['component2Value']
+        }
+      }
+    }
+
+    const result = normalizePayload(request, h)
+
+    // Check if the transformation took place
+    expect(request.payload.answers).toEqual([
+      { questionId: 'component1Name', answers: ['component1Value'] },
+      { questionId: 'component2Name', answers: ['component2Value'] }
+    ])
+
+    // Ensure original data property is deleted
+    expect(request.payload.data).toBeUndefined()
+
+    // Check that the function proceeds with the lifecycle
+    expect(result).toBe(h.continue)
+  })
+
+  it('should leave answers format unchanged if it is already in answers format', () => {
+    const request = {
+      payload: {
+        answers: [
+          { questionId: 'component1Name', answers: ['component1Value'] }
+        ]
+      }
+    }
+
+    const result = normalizePayload(request, h)
+
+    // Check that answers remain unchanged
+    expect(request.payload.answers).toEqual([
+      { questionId: 'component1Name', answers: ['component1Value'] }
+    ])
+
+    // Ensure no modification to the answers
+    expect(request.payload.data).toBeUndefined()
+
+    // Check that the function proceeds with the lifecycle
+    expect(result).toBe(h.continue)
+  })
+
+  it('should not fail if no data or answers property is present', () => {
+    const request = {
+      payload: {}
+    }
+
+    const result = normalizePayload(request, h)
+
+    // Ensure no changes to the payload
+    expect(request.payload.answers).toBeUndefined()
+    expect(request.payload.data).toBeUndefined()
+
+    // Check that the function proceeds with the lifecycle
+    expect(result).toBe(h.continue)
+  })
+
+  it('should prioritize data over existing answers', () => {
+    const request = {
+      payload: {
+        data: {
+          component1Name: ['component1Value']
+        },
+        answers: [
+          { questionId: 'component2Name', answers: ['component2Value'] }
+        ]
+      }
+    }
+
+    const result = normalizePayload(request, h)
+
+    // Check that data is transformed and answers are removed
+    expect(request.payload.answers).toEqual([
+      { questionId: 'component1Name', answers: ['component1Value'] }
+    ])
+
+    expect(request.payload.data).toBeUndefined()
+
+    // Check that the function proceeds with the lifecycle
+    expect(result).toBe(h.continue)
+  })
+})

--- a/src/api/scoring/index.js
+++ b/src/api/scoring/index.js
@@ -1,5 +1,6 @@
 import Joi from 'joi'
 import { scoringController } from '~/src/api/scoring/controller.js'
+import { normalizePayload } from './dxt-normaliser.js'
 
 /**
  * @satisfies {ServerRegisterPluginObject<void>}
@@ -13,17 +14,28 @@ const scoring = {
         path: '/scoring/api/v1/{grantType}/score',
         ...scoringController,
         options: {
+          pre: [{ method: normalizePayload }],
           validate: {
-            payload: Joi.object({
-              answers: Joi.array()
-                .items(
-                  Joi.object({
-                    questionId: Joi.string().required(),
-                    answers: Joi.array().items(Joi.string()).min(1).required()
-                  })
-                )
-                .required()
-            })
+            payload: Joi.alternatives().try(
+              Joi.object({
+                data: Joi.object()
+                  .pattern(
+                    Joi.string(),
+                    Joi.array().items(Joi.string()).min(1).required()
+                  )
+                  .required()
+              }),
+              Joi.object({
+                answers: Joi.array()
+                  .items(
+                    Joi.object({
+                      questionId: Joi.string().required(),
+                      answers: Joi.array().items(Joi.string()).min(1).required()
+                    })
+                  )
+                  .required()
+              })
+            )
           }
         }
       })

--- a/src/api/scoring/index.js
+++ b/src/api/scoring/index.js
@@ -17,20 +17,38 @@ const scoring = {
           pre: [{ method: normalizePayload }],
           validate: {
             payload: Joi.alternatives().try(
+              // For DXT request with data.main
               Joi.object({
-                data: Joi.object()
-                  .pattern(
-                    Joi.string(),
-                    Joi.array().items(Joi.string()).min(1).required()
-                  )
-                  .required()
+                data: Joi.object({
+                  main: Joi.object()
+                    .pattern(
+                      Joi.string(),
+                      Joi.alternatives().try(
+                        Joi.string(),
+                        Joi.number(),
+                        Joi.array().items(Joi.string(), Joi.number()),
+                        Joi.valid(null)
+                      )
+                    )
+                    .required()
+                }).required()
               }),
+              // For already normalized answers format
               Joi.object({
                 answers: Joi.array()
                   .items(
                     Joi.object({
                       questionId: Joi.string().required(),
-                      answers: Joi.array().items(Joi.string()).min(1).required()
+                      answers: Joi.array()
+                        .items(
+                          Joi.alternatives().try(
+                            Joi.string(),
+                            Joi.number(),
+                            Joi.valid(null)
+                          )
+                        )
+                        .min(1)
+                        .required()
                     })
                   )
                   .required()


### PR DESCRIPTION
### Summary:
This PR introduces the **DXT normalizer** to transform and normalize request payloads coming from DXT. The normalization ensures that payloads are consistently formatted, regardless of whether the data.main is received in key-value pairs or in an already normalized `answers` format. Additionally, request validation is added as is required in Hapi and also to ensure that the payload structure adheres to the expected schema.

Postman updates have been made to facilitate manual testing of the different request payload formats.

### Changes:
- **DXT Normalizer**: 
  - Implemented a pre-handler that checks if the payload is in key-value format (`data.main`) or already in the expected `answers` format.
  - Transformed the `data.main` into the `answers` array format if necessary.
  - If the payload is already in the correct `answers` format, no changes are made.
- **Request Validation**: 
  - Added a validation schema for the scoring API endpoint to handle both potential payload formats (key-value and `answers`).
  - Used Joi to enforce the validation of incoming request bodies, ensuring that the format is correct before processing.
- **Endpoint Adjustments**: 
  - Updated the `/scoring/api/v1/{grantType}/score` endpoint to apply the DXT normalizer and request validation.
- **Postman Updates**:
  - Added environment variables and dynamic body handling to facilitate testing of both request formats (key-value and answers).
  - Updated the Postman collection to allow easy switching between payload formats, enabling manual testing with the updated API.

### How to test:
1. Test the endpoint `/scoring/api/v1/{grantType}/score` with different request payload formats:
   - **Key-Value Format**: 
     ```json
     {
       "data": {
           "main": {
                "component1Name": "component1Value",
                "component2Name": "component2Value"
           }
       }
     }
     ```
   - **Answers Format**: 
     ```json
     {
       "answers": [
         { "questionId": "component1Name", "answers": ["component1Value"] },
         { "questionId": "component2Name", "answers": ["component2Value"] }
       ]
     }
     ```
2. Ensure that the response is consistent and the payload is correctly transformed (if necessary) and validated.
3. Check that invalid payloads (e.g., missing required fields) are rejected with appropriate validation errors.

### Related JIRA Card:
[JIRA-557] - E2E basic scoring journey (Add DXT normalizer with request validation)

### Additional Notes:
- No breaking changes expected in the API.
- This change is backward-compatible with the existing `answers` format.
- Postman updates provide an easier way to manually test the API with various request payload formats.
