### PR TITLE
fix: added JSON format to caught errors that partially match JOI validation errors

### DIFF
--- a/src/api/scoring/handler.js
+++ b/src/api/scoring/handler.js
@@ -7,25 +7,47 @@ import { log, LogCodes } from '../logging/log.js'
 export const handler = (request, h) => {
   const { answers } = request.payload
   const { grantType } = request.params
-  log(LogCodes.SCORING.REQUEST_RECEIVED, { grantType, answers })
+  log(LogCodes.SCORING.REQUEST_RECEIVED, {
+    msg: 'Scoring request received',
+    grantType,
+    answers
+  })
   const scoringConfig = getScoringConfig(grantType)
 
   if (!scoringConfig) {
-    log(LogCodes.SCORING.CONFIG_MISSING, { grantType })
+    log(LogCodes.SCORING.CONFIG_MISSING, {
+      msg: 'Grant type not found',
+      grantType
+    })
     return h
       .response({ error: 'Invalid grant type' })
       .code(statusCodes.badRequest)
   }
-  log(LogCodes.SCORING.CONFIG_FOUND, { grantType, scoringConfig })
+  log(LogCodes.SCORING.CONFIG_FOUND, {
+    msg: 'Grant type scoring data found',
+    grantType,
+    scoringConfig
+  })
 
   try {
     // Find matching scoring data for the provided questionIds
     const rawScores = score(scoringConfig)(answers)
     const finalResult = mapToFinalResult(scoringConfig, rawScores)
-    log(LogCodes.SCORING.FINAL_RESULT, { grantType, rawScores, finalResult })
+    log(LogCodes.SCORING.FINAL_RESULT, {
+      msg: 'Scoring final results',
+      grantType,
+      rawScores,
+      finalResult
+    })
     return h.response(finalResult).code(statusCodes.ok)
   } catch (error) {
     log(LogCodes.SCORING.CONVERSION_ERROR, { grantType, error })
-    return h.response(error.message).code(statusCodes.badRequest)
+    return h
+      .response({
+        statusCode: statusCodes.badRequest,
+        error: 'Bad Request',
+        message: error.message
+      })
+      .code(statusCodes.badRequest)
   }
 }

--- a/src/api/scoring/handler.js
+++ b/src/api/scoring/handler.js
@@ -7,38 +7,22 @@ import { log, LogCodes } from '../logging/log.js'
 export const handler = (request, h) => {
   const { answers } = request.payload
   const { grantType } = request.params
-  log(LogCodes.SCORING.REQUEST_RECEIVED, {
-    msg: 'Scoring request received',
-    grantType,
-    answers
-  })
+  log(LogCodes.SCORING.REQUEST_RECEIVED, { grantType, answers })
   const scoringConfig = getScoringConfig(grantType)
 
   if (!scoringConfig) {
-    log(LogCodes.SCORING.CONFIG_MISSING, {
-      msg: 'Grant type not found',
-      grantType
-    })
+    log(LogCodes.SCORING.CONFIG_MISSING, { grantType })
     return h
       .response({ error: 'Invalid grant type' })
       .code(statusCodes.badRequest)
   }
-  log(LogCodes.SCORING.CONFIG_FOUND, {
-    msg: 'Grant type scoring data found',
-    grantType,
-    scoringConfig
-  })
+  log(LogCodes.SCORING.CONFIG_FOUND, { grantType, scoringConfig })
 
   try {
     // Find matching scoring data for the provided questionIds
     const rawScores = score(scoringConfig)(answers)
     const finalResult = mapToFinalResult(scoringConfig, rawScores)
-    log(LogCodes.SCORING.FINAL_RESULT, {
-      msg: 'Scoring final results',
-      grantType,
-      rawScores,
-      finalResult
-    })
+    log(LogCodes.SCORING.FINAL_RESULT, { grantType, rawScores, finalResult })
     return h.response(finalResult).code(statusCodes.ok)
   } catch (error) {
     log(LogCodes.SCORING.CONVERSION_ERROR, { grantType, error })

--- a/src/api/scoring/handler.test.js
+++ b/src/api/scoring/handler.test.js
@@ -76,10 +76,14 @@ describe('Handler Function', () => {
   })
 
   it('should return 400 response with the error message when scoring fails', async () => {
-    const errorMessage =
-      'Question with id invalidQuestion not found in scoringData.'
+    const errorMessage = {
+      error: 'Bad Request',
+      message: 'Question with id invalidQuestion not found in scoringData.',
+      statusCode: 400
+    }
+
     score.mockImplementation(() => {
-      throw new Error(errorMessage)
+      throw new Error(errorMessage.message)
     })
     getScoringConfig.mockReturnValue(mockScoringConfig)
 
@@ -90,9 +94,14 @@ describe('Handler Function', () => {
   })
 
   it('should return a 400 response with the error message when mapping fails', async () => {
-    const errorMessage = 'Mapping error occurred.'
+    const errorMessage = {
+      error: 'Bad Request',
+      message: 'Mapping error occurred.',
+      statusCode: 400
+    }
+
     mapToFinalResult.mockImplementation(() => {
-      throw new Error(errorMessage)
+      throw new Error(errorMessage.message)
     })
     score.mockReturnValue(jest.fn().mockReturnValue(mockRawScores))
     getScoringConfig.mockReturnValue(mockScoringConfig)


### PR DESCRIPTION
Validation errors caught in code rather than JOI only returned strings as the response's body.  e.g. `Question with id invalidQuestion not found in scoringData.`

This PR returns all caught errors as responses that partially match JOI responses. The handler's caught errors will now return a structure like the one below.

```
{
      error: 'Bad Request',
      message: 'Question with id invalidQuestion not found in scoringData.',
      statusCode: 400
}
```