### PR TITLE
fix: check for illegal answer values and throw errors accordingly.

### DIFF
--- a/src/services/scoring/methods/multi-score.js
+++ b/src/services/scoring/methods/multi-score.js
@@ -7,6 +7,12 @@
  * @throws {Error} Throws if none of the `userAnswers` are found in the scoring rules.
  */
 function multiScore(questionScoringConfig, userAnswers) {
+  if (!Array.isArray(userAnswers) || userAnswers.length === 0) {
+    throw new Error(
+      `Answers not provided for question: ${questionScoringConfig.id}.`
+    )
+  }
+
   const scores = userAnswers.map((userAnswer) => {
     const matchingAnswer = questionScoringConfig.answers.find(
       (answer) => answer.answer === userAnswer

--- a/src/services/scoring/methods/multi-score.test.js
+++ b/src/services/scoring/methods/multi-score.test.js
@@ -59,4 +59,10 @@ describe('multiScore', () => {
       multiScore(questionConfig, ['F']) // Invalid answer
     }).toThrow('Answer "F" not found in question: multiAnswer.')
   })
+
+  it('should throw an error when answer is not provided', () => {
+    expect(() => {
+      multiScore(questionConfig, []) // No answer provided
+    }).toThrow('Answers not provided for question: multiAnswer.')
+  })
 })

--- a/src/services/scoring/methods/single-score.js
+++ b/src/services/scoring/methods/single-score.js
@@ -6,6 +6,10 @@
  * @throws {Error} Throws if the `userAnswer` is not found in the scoring rules.
  */
 function singleScore(questionScoringConfig, userAnswers) {
+  if (!Array.isArray(userAnswers) || userAnswers.length === 0) {
+    throw new Error("Answer not provided and can't be scored.")
+  }
+
   if (userAnswers.length > 1) {
     throw new Error(
       `Multiple answers provided for single-answer question: ${questionScoringConfig.id}`

--- a/src/services/scoring/methods/single-score.test.js
+++ b/src/services/scoring/methods/single-score.test.js
@@ -47,6 +47,16 @@ describe('singleScore', () => {
     )
   })
 
+  it('should throw an error when an answer is not provided', () => {
+    const illegalAnswers = [[], undefined, null]
+
+    illegalAnswers.forEach((answers) => {
+      expect(() => singleScore(questionConfig, answers)).toThrow(
+        `Answer not provided and can't be scored.`
+      )
+    })
+  })
+
   it('should throw an error when answer is not found', () => {
     expect(() => {
       singleScore(questionConfig, ['C'])


### PR DESCRIPTION
Added checks for illegal answers such as `[]`, `null` or `undefined` and responding with errors accordingly.