### PR TITLE
fix: added meta, files and repeater keys to JOI validation on DXT request formats

### DIFF
--- a/src/api/scoring/index.js
+++ b/src/api/scoring/index.js
@@ -19,7 +19,10 @@ const scoring = {
             payload: Joi.alternatives().try(
               // For DXT request with data.main
               Joi.object({
+                meta: Joi.any(),
                 data: Joi.object({
+                  files: Joi.object(),
+                  repeaters: Joi.object(),
                   main: Joi.object()
                     .pattern(
                       Joi.string(),


### PR DESCRIPTION
Added JOI definitions for the full DXT schema as we are expecting data in a format:

```
{
  "data": {
    "main": { ... }, // form answers ( Record<questionId, answerId | answerId[] > )
    "files": { ... },
    "repeaters": { ... }
  },
  "meta": { ... }
}
```