### PR TITLE
Tgc 544 scoring service validation

### DIFF
--- a/src/api/logging/log.js
+++ b/src/api/logging/log.js
@@ -62,11 +62,9 @@ const validateLogParams = ({ level, event }, context) => {
     context: typeof context !== 'object' || Array.isArray(context)
   }
 
-  const invalidField = Object.keys({
-    level: !level,
-    event: !event,
-    context: typeof context !== 'object'
-  }).find((key) => validationErrors[key])
+  const invalidField = Object.keys(validationErrors).find(
+    (key) => validationErrors[key]
+  )
 
   if (invalidField) {
     throw new Error(

--- a/src/api/scoring/dxt-normaliser.js
+++ b/src/api/scoring/dxt-normaliser.js
@@ -44,7 +44,7 @@ export const normalizePayload = (request, h) => {
   const { data } = request.payload
 
   if (data?.main) {
-    request.payload.answers = Object.entries(data.main).map(([key, value]) => {
+    request.payload = Object.entries(data.main).map(([key, value]) => {
       let answers = []
 
       if (Array.isArray(value)) {

--- a/src/api/scoring/dxt-normaliser.test.js
+++ b/src/api/scoring/dxt-normaliser.test.js
@@ -21,7 +21,7 @@ describe('normalizePayload', () => {
     const result = normalizePayload(request, h)
 
     // Check if the transformation took place
-    expect(request.payload.answers).toEqual([
+    expect(request.payload).toEqual([
       { questionId: 'component1Name', answers: ['component1Value'] },
       { questionId: 'component2Name', answers: ['component2Value'] }
     ])
@@ -44,7 +44,7 @@ describe('normalizePayload', () => {
       }
     }
     const response = normalizePayload(request, h)
-    expect(request.payload.answers).toEqual([
+    expect(request.payload).toEqual([
       { questionId: 'component1Name', answers: ['component1Value'] }
     ])
     expect(response).toBe(h.continue)
@@ -61,7 +61,7 @@ describe('normalizePayload', () => {
       }
     }
     const response = normalizePayload(request, h)
-    expect(request.payload.answers).toEqual([
+    expect(request.payload).toEqual([
       { questionId: 'component1Name', answers: [42] }
     ])
     expect(response).toBe(h.continue)
@@ -78,7 +78,7 @@ describe('normalizePayload', () => {
       }
     }
     const response = normalizePayload(request, h)
-    expect(request.payload.answers).toEqual([
+    expect(request.payload).toEqual([
       { questionId: 'component1Name', answers: ['value1', 'value2'] }
     ])
     expect(response).toBe(h.continue)
@@ -95,7 +95,7 @@ describe('normalizePayload', () => {
       }
     }
     const response = normalizePayload(request, h)
-    expect(request.payload.answers).toEqual([
+    expect(request.payload).toEqual([
       { questionId: 'component1Name', answers: [1, 2, 3] }
     ])
     expect(response).toBe(h.continue)
@@ -112,7 +112,7 @@ describe('normalizePayload', () => {
       }
     }
     const response = normalizePayload(request, h)
-    expect(request.payload.answers).toEqual([
+    expect(request.payload).toEqual([
       { questionId: 'component1Name', answers: [] }
     ])
     expect(response).toBe(h.continue)
@@ -129,7 +129,7 @@ describe('normalizePayload', () => {
       }
     }
     const response = normalizePayload(request, h)
-    expect(request.payload.answers).toEqual([
+    expect(request.payload).toEqual([
       { questionId: 'component1Name', answers: [] }
     ])
     expect(response).toBe(h.continue)
@@ -144,23 +144,19 @@ describe('normalizePayload', () => {
       }
     }
     const response = normalizePayload(request, h)
-    expect(request.payload.answers).toEqual([])
+    expect(request.payload).toEqual([])
     expect(response).toBe(h.continue)
   })
 
   it('should leave answers format unchanged if it is already in answers format', () => {
     const request = {
-      payload: {
-        answers: [
-          { questionId: 'component1Name', answers: ['component1Value'] }
-        ]
-      }
+      payload: [{ questionId: 'component1Name', answers: ['component1Value'] }]
     }
 
     const result = normalizePayload(request, h)
 
     // Check that answers remain unchanged
-    expect(request.payload.answers).toEqual([
+    expect(request.payload).toEqual([
       { questionId: 'component1Name', answers: ['component1Value'] }
     ])
 
@@ -180,33 +176,6 @@ describe('normalizePayload', () => {
 
     // Ensure no changes to the payload
     expect(request.payload.answers).toBeUndefined()
-    expect(request.payload.data).toBeUndefined()
-
-    // Check that the function proceeds with the lifecycle
-    expect(result).toBe(h.continue)
-  })
-
-  it('should prioritize data over existing answers', () => {
-    const request = {
-      payload: {
-        data: {
-          main: {
-            component1Name: ['component1Value']
-          }
-        },
-        answers: [
-          { questionId: 'component2Name', answers: ['component2Value'] }
-        ]
-      }
-    }
-
-    const result = normalizePayload(request, h)
-
-    // Check that data is transformed and answers are removed
-    expect(request.payload.answers).toEqual([
-      { questionId: 'component1Name', answers: ['component1Value'] }
-    ])
-
     expect(request.payload.data).toBeUndefined()
 
     // Check that the function proceeds with the lifecycle

--- a/src/api/scoring/handler.js
+++ b/src/api/scoring/handler.js
@@ -5,7 +5,7 @@ import { statusCodes } from '../common/constants/status-codes.js'
 import { log, LogCodes } from '../logging/log.js'
 
 export const handler = (request, h) => {
-  const { answers } = request.payload
+  const answers = request.payload
   const { grantType } = request.params
   log(LogCodes.SCORING.REQUEST_RECEIVED, { grantType, answers })
   const scoringConfig = getScoringConfig(grantType)
@@ -25,7 +25,10 @@ export const handler = (request, h) => {
     log(LogCodes.SCORING.FINAL_RESULT, { grantType, rawScores, finalResult })
     return h.response(finalResult).code(statusCodes.ok)
   } catch (error) {
-    log(LogCodes.SCORING.CONVERSION_ERROR, { grantType, error })
+    log(LogCodes.SCORING.CONVERSION_ERROR, {
+      grantType,
+      message: error.message
+    })
     return h
       .response({
         statusCode: statusCodes.badRequest,

--- a/src/api/scoring/handler.test.js
+++ b/src/api/scoring/handler.test.js
@@ -37,7 +37,7 @@ describe('Handler Function', () => {
   ]
 
   const mockRequest = (grantType = 'example-grant', answers = mockAnswers) => ({
-    payload: { answers },
+    payload: answers,
     params: { grantType }
   })
 

--- a/src/api/scoring/index.js
+++ b/src/api/scoring/index.js
@@ -16,47 +16,78 @@ const scoring = {
         options: {
           pre: [{ method: normalizePayload }],
           validate: {
-            payload: Joi.alternatives().try(
-              // For DXT request with data.main
-              Joi.object({
-                meta: Joi.any(),
-                data: Joi.object({
-                  files: Joi.object(),
-                  repeaters: Joi.object(),
-                  main: Joi.object()
-                    .pattern(
-                      Joi.string(),
-                      Joi.alternatives().try(
+            payload: Joi.alternatives()
+              .try(
+                // DXT request with data.main
+                Joi.object({
+                  meta: Joi.any(),
+                  data: Joi.object({
+                    files: Joi.object(),
+                    repeaters: Joi.object(),
+                    main: Joi.object()
+                      .pattern(
                         Joi.string(),
-                        Joi.number(),
-                        Joi.array().items(Joi.string(), Joi.number()),
-                        Joi.valid(null)
+                        Joi.alternatives().try(
+                          Joi.string(),
+                          Joi.number(),
+                          Joi.array().items(Joi.string(), Joi.number()),
+                          Joi.valid(null)
+                        )
                       )
-                    )
+                      .required()
+                      .messages({
+                        'object.base': '"main" must be an object',
+                        'any.required': '"main" field is missing inside "data"'
+                      })
+                  })
                     .required()
-                }).required()
-              }),
-              // For already normalized answers format
-              Joi.object({
-                answers: Joi.array()
+                    .messages({
+                      'object.base':
+                        '"data" must be an object when using this format',
+                      'any.required':
+                        'Expected an object with "data", but received something else'
+                    })
+                }),
+
+                // Already normalized answers format (array)
+                Joi.array()
                   .items(
                     Joi.object({
-                      questionId: Joi.string().required(),
+                      questionId: Joi.string().required().messages({
+                        'string.base': '"questionId" must be a string',
+                        'string.empty': '"questionId" cannot be empty'
+                      }),
                       answers: Joi.array()
                         .items(
-                          Joi.alternatives().try(
-                            Joi.string(),
-                            Joi.number(),
-                            Joi.valid(null)
-                          )
+                          Joi.alternatives()
+                            .try(Joi.string(), Joi.number())
+                            .messages({
+                              'alternatives.types':
+                                '"answers" must be a string or number'
+                            })
                         )
                         .min(1)
                         .required()
+                        .messages({
+                          'array.base': '"answers" must be an array',
+                          'array.min': '"answers" cannot be an empty array"',
+                          'any.required': '"answers" is required'
+                        })
                     })
                   )
                   .required()
+                  .min(1)
+                  .messages({
+                    'array.base': 'Request body must be an array of objects',
+                    'array.min': 'Array cannot be empty',
+                    'any.required':
+                      'Request body is required and must be an array'
+                  })
+              )
+              .messages({
+                'alternatives.types':
+                  'Request body must be either an object with "data.main" or an array of answers'
               })
-            )
           }
         }
       })

--- a/src/api/scoring/index.js
+++ b/src/api/scoring/index.js
@@ -1,4 +1,4 @@
-import Joi from 'joi'
+import { scoringPayloadSchema } from './validation.js'
 import { scoringController } from '~/src/api/scoring/controller.js'
 import { normalizePayload } from './dxt-normaliser.js'
 
@@ -16,78 +16,7 @@ const scoring = {
         options: {
           pre: [{ method: normalizePayload }],
           validate: {
-            payload: Joi.alternatives()
-              .try(
-                // DXT request with data.main
-                Joi.object({
-                  meta: Joi.any(),
-                  data: Joi.object({
-                    files: Joi.object(),
-                    repeaters: Joi.object(),
-                    main: Joi.object()
-                      .pattern(
-                        Joi.string(),
-                        Joi.alternatives().try(
-                          Joi.string(),
-                          Joi.number(),
-                          Joi.array().items(Joi.string(), Joi.number()),
-                          Joi.valid(null)
-                        )
-                      )
-                      .required()
-                      .messages({
-                        'object.base': '"main" must be an object',
-                        'any.required': '"main" field is missing inside "data"'
-                      })
-                  })
-                    .required()
-                    .messages({
-                      'object.base':
-                        '"data" must be an object when using this format',
-                      'any.required':
-                        'Expected an object with "data", but received something else'
-                    })
-                }),
-
-                // Already normalized answers format (array)
-                Joi.array()
-                  .items(
-                    Joi.object({
-                      questionId: Joi.string().required().messages({
-                        'string.base': '"questionId" must be a string',
-                        'string.empty': '"questionId" cannot be empty'
-                      }),
-                      answers: Joi.array()
-                        .items(
-                          Joi.alternatives()
-                            .try(Joi.string(), Joi.number())
-                            .messages({
-                              'alternatives.types':
-                                '"answers" must be a string or number'
-                            })
-                        )
-                        .min(1)
-                        .required()
-                        .messages({
-                          'array.base': '"answers" must be an array',
-                          'array.min': '"answers" cannot be an empty array"',
-                          'any.required': '"answers" is required'
-                        })
-                    })
-                  )
-                  .required()
-                  .min(1)
-                  .messages({
-                    'array.base': 'Request body must be an array of objects',
-                    'array.min': 'Array cannot be empty',
-                    'any.required':
-                      'Request body is required and must be an array'
-                  })
-              )
-              .messages({
-                'alternatives.types':
-                  'Request body must be either an object with "data.main" or an array of answers'
-              })
+            payload: scoringPayloadSchema
           }
         }
       })

--- a/src/api/scoring/validation.js
+++ b/src/api/scoring/validation.js
@@ -1,0 +1,68 @@
+import Joi from 'joi'
+
+export const scoringPayloadSchema = Joi.alternatives()
+  .try(
+    // DXT request with data.main
+    Joi.object({
+      meta: Joi.any(),
+      data: Joi.object({
+        files: Joi.object(),
+        repeaters: Joi.object(),
+        main: Joi.object()
+          .pattern(
+            Joi.string(),
+            Joi.alternatives().try(
+              Joi.string(),
+              Joi.number(),
+              Joi.array().items(Joi.string(), Joi.number()),
+              Joi.valid(null)
+            )
+          )
+          .required()
+          .messages({
+            'object.base': '"main" must be an object',
+            'any.required': '"main" field is missing inside "data"'
+          })
+      })
+        .required()
+        .messages({
+          'object.base': '"data" must be an object when using this format',
+          'any.required':
+            'Expected an object with "data", but received something else'
+        })
+    }),
+
+    // Already normalized answers format (array)
+    Joi.array()
+      .items(
+        Joi.object({
+          questionId: Joi.string().required().messages({
+            'string.base': '"questionId" must be a string',
+            'string.empty': '"questionId" cannot be empty',
+            'any.required': '"questionId" is required'
+          }),
+          answers: Joi.array()
+            .items(
+              Joi.alternatives().try(Joi.string(), Joi.number()).messages({
+                'alternatives.types': '"answers" must be a string or number'
+              })
+            )
+            .min(1)
+            .required()
+            .messages({
+              'array.base': '"answers" must be an array',
+              'array.min': '"answers" cannot be an empty array"',
+              'any.required': '"answers" is required'
+            })
+        })
+      )
+      .required()
+      .min(1)
+      .messages({
+        'array.min': 'Array cannot be empty'
+      })
+  )
+  .messages({
+    'alternatives.types':
+      'Request body must be either an object with "data.main" or an array of answers'
+  })

--- a/src/api/scoring/validation.test.js
+++ b/src/api/scoring/validation.test.js
@@ -1,0 +1,192 @@
+import { scoringPayloadSchema } from './validation.js'
+
+describe('Scoring Payload Validation', () => {
+  describe('DXT', () => {
+    describe('valid', () => {
+      it('should validate a correct payload with data.main', () => {
+        const validPayload = {
+          data: {
+            main: {
+              someKey: 'someValue'
+            }
+          }
+        }
+
+        const { error } = scoringPayloadSchema.validate(validPayload)
+
+        expect(error).toBeUndefined()
+      })
+    })
+
+    describe('errors', () => {
+      describe('main', () => {
+        it('should return error for missing "main" in object format', () => {
+          const invalidPayload = {
+            data: {}
+          }
+
+          const { error } = scoringPayloadSchema.validate(invalidPayload)
+
+          expect(error).toBeDefined()
+          expect(error.details[0].message).toBe(
+            '"main" field is missing inside "data"'
+          )
+        })
+
+        it('should return error for invalid "main" format', () => {
+          const invalidPayload = {
+            data: {
+              main: 'invalid-string'
+            }
+          }
+
+          const { error } = scoringPayloadSchema.validate(invalidPayload)
+
+          expect(error).toBeDefined()
+          expect(error.details[0].message).toBe('"main" must be an object')
+        })
+      })
+
+      describe('root level', () => {
+        it('should return error for invalid "data" type (not an object)', () => {
+          const invalidPayload = {
+            data: 'string-instead-of-object' // Invalid type for "data"
+          }
+
+          const { error } = scoringPayloadSchema.validate(invalidPayload)
+
+          expect(error).toBeDefined()
+          expect(error.details[0].message).toBe(
+            '"data" must be an object when using this format'
+          )
+        })
+
+        it('should return error for missing "data" field', () => {
+          const invalidPayload = {} // Missing "data" field
+
+          const { error } = scoringPayloadSchema.validate(invalidPayload)
+
+          expect(error).toBeDefined()
+          expect(error.details[0].message).toBe(
+            'Expected an object with "data", but received something else'
+          )
+        })
+      })
+    })
+  })
+
+  describe('Standard', () => {
+    describe('valid', () => {
+      it('should validate correct array format', () => {
+        const validPayload = [{ questionId: 'q1', answers: ['answer1'] }]
+
+        const { error } = scoringPayloadSchema.validate(validPayload)
+
+        expect(error).toBeUndefined()
+      })
+    })
+
+    describe('errors', () => {
+      describe('questionId', () => {
+        it('should return error for missing "questionId" in array format', () => {
+          const invalidPayload = [{ answers: ['answer1'] }]
+
+          const { error } = scoringPayloadSchema.validate(invalidPayload)
+
+          expect(error).toBeDefined()
+          expect(error.details[0].message).toBe('"questionId" is required')
+        })
+
+        it('should return error for "questionId" not being a string', () => {
+          const invalidPayload = [
+            { questionId: 123, answers: ['answer1'] } // Invalid type for "questionId"
+          ]
+
+          const { error } = scoringPayloadSchema.validate(invalidPayload)
+
+          expect(error).toBeDefined()
+          expect(error.details[0].message).toBe('"questionId" must be a string')
+        })
+
+        it('should return error for "questionId" being an empty string', () => {
+          const invalidPayload = [
+            { questionId: '', answers: ['answer1'] } // "questionId" is an empty string
+          ]
+
+          const { error } = scoringPayloadSchema.validate(invalidPayload)
+
+          expect(error).toBeDefined()
+          expect(error.details[0].message).toBe('"questionId" cannot be empty')
+        })
+      })
+
+      describe('answers', () => {
+        it('should return error for missing "answers" in array format', () => {
+          const invalidPayload = [{ questionId: 'q1' }]
+
+          const { error } = scoringPayloadSchema.validate(invalidPayload)
+
+          expect(error).toBeDefined()
+          expect(error.details[0].message).toBe('"answers" is required')
+        })
+
+        it('should return error for empty "answers" array in array format', () => {
+          const invalidPayload = [{ questionId: 'q1', answers: [] }]
+
+          const { error } = scoringPayloadSchema.validate(invalidPayload)
+
+          expect(error).toBeDefined()
+          expect(error.details[0].message).toBe(
+            '"answers" cannot be an empty array"'
+          )
+        })
+
+        it('should return error for invalid type in "answers" array', () => {
+          const invalidPayload = [{ questionId: 'q1', answers: [{}, []] }]
+
+          const { error } = scoringPayloadSchema.validate(invalidPayload)
+
+          expect(error).toBeDefined()
+          expect(error.details[0].message).toBe(
+            '"answers" must be a string or number'
+          )
+        })
+
+        it('should return error for "answers" not being an array', () => {
+          const invalidPayload = [
+            { questionId: 'q1', answers: 'not-an-array' } // Invalid type for "answers"
+          ]
+
+          const { error } = scoringPayloadSchema.validate(invalidPayload)
+
+          expect(error).toBeDefined()
+          expect(error.details[0].message).toBe('"answers" must be an array')
+        })
+      })
+
+      describe('root level', () => {
+        it('should return error for empty array format', () => {
+          const invalidPayload = []
+
+          const { error } = scoringPayloadSchema.validate(invalidPayload)
+
+          expect(error).toBeDefined()
+          expect(error.details[0].message).toBe('Array cannot be empty')
+        })
+      })
+    })
+  })
+
+  describe('Error - Both', () => {
+    it('should return error for invalid root-level structure', () => {
+      const invalidPayload = 'invalid-payload'
+
+      const { error } = scoringPayloadSchema.validate(invalidPayload)
+
+      expect(error).toBeDefined()
+      expect(error.details[0].message).toBe(
+        'Request body must be either an object with "data.main" or an array of answers'
+      )
+    })
+  })
+})


### PR DESCRIPTION
This PR addresses the issue where certain validation messages are missing from the logs when business rules are violated, even though Joi schema validation passes. Specifically, the missing messages are triggered by:

- A question that cannot be matched in the scoring config.
- An answer that cannot be matched in the scoring config.
- Multiple answers to a singleScore question.

Previously, these cases resulted in error logs without accompanying messages and a non-JSON response.

To improve consistency, this update ensures that all validation errors (both Joi and business rule failures) generate clear, uniform log messages and return consistent JSON responses across the application. This change enhances debugging and ensures better traceability for validation failures.

Tech notes:
- This PR changes the standard expected request body from:
```
{
  answers: [
    {"questionId": "/products-processed", "answers": ["products-processed-A1"] },
    {"questionId": "/adding-value", "answers": ["adding-value-A1"] }
  ]
}
```
to:
```
[
 { "questionId": "/products-processed", "answers": ["products-processed-A1"] },
 { "questionId": "/adding-value", "answers": ["adding-value-A1"] }
]
```
- Extracted validation to a separate file and added test coverage
- Conditional logic included in dxt normalizer that does the right body transformation (if the request body contains a single answer it wraps it in array, if multiple answers wrapped in array already it passes it on, otherwise it creates empty array)
- Minor code cleanup in logging handler to improve readability