### PR TITLE
feat: Service accepts questions that it doesn't have scoring ID's for but ignores them. Errors will be thrown when a required scoring question is not included in the results

### DIFF
--- a/src/api/scoring/handler.js
+++ b/src/api/scoring/handler.js
@@ -16,7 +16,7 @@ export const handler = (request, h) => {
       .response({ error: 'Invalid grant type' })
       .code(statusCodes.badRequest)
   }
-  log(LogCodes.SCORING.CONFIG_FOUND, { grantType, scoringConfig })
+  log(LogCodes.SCORING.CONFIG_FOUND, { grantType })
 
   try {
     // Find matching scoring data for the provided questionIds

--- a/src/api/scoring/handler.js
+++ b/src/api/scoring/handler.js
@@ -16,7 +16,7 @@ export const handler = (request, h) => {
       .response({ error: 'Invalid grant type' })
       .code(statusCodes.badRequest)
   }
-  log(LogCodes.SCORING.CONFIG_FOUND, { grantType })
+  log(LogCodes.SCORING.CONFIG_FOUND, { grantType, scoringConfig })
 
   try {
     // Find matching scoring data for the provided questionIds

--- a/src/config/grants/adding-value-grant-config.js
+++ b/src/config/grants/adding-value-grant-config.js
@@ -64,7 +64,7 @@ const addingValueGrantConfig = {
         IMPROVE_PROCESSING_AND_SUPPLY_CHAINS,
         GROW_YOUR_BUSINESS
       ],
-      scoreMethod: singleScore,
+      scoreMethod: multiScore,
       answers: [
         { answer: 'project-impact-A1', score: 7 },
         { answer: 'project-impact-A2', score: 6 },
@@ -72,11 +72,11 @@ const addingValueGrantConfig = {
         { answer: 'project-impact-A4', score: 4 }
       ],
       scoreBand: [
-        { name: ScoreBands.WEAK, minValue: 0, maxValue: 3 },
-        { name: ScoreBands.MEDIUM, minValue: 4, maxValue: 5 },
-        { name: ScoreBands.STRONG, minValue: 6, maxValue: 7 }
+        { name: ScoreBands.WEAK, minValue: 0, maxValue: 10 },
+        { name: ScoreBands.MEDIUM, minValue: 11, maxValue: 16 },
+        { name: ScoreBands.STRONG, minValue: 17, maxValue: 22 }
       ],
-      maxScore: 8
+      maxScore: 22
     },
     {
       id: '/future-customers',

--- a/src/services/scoring/score.js
+++ b/src/services/scoring/score.js
@@ -12,6 +12,7 @@ function score(scoringConfig) {
       (value) => value.id
     )
 
+    // @todo - This code is not optimised and can be improved
     // filter out all userAnswers that are not in the scoring data
     const filteredAnswers = userAnswers.filter(({ questionId }) =>
       scoringConfigQuestionIds.includes(questionId)

--- a/src/services/scoring/score.js
+++ b/src/services/scoring/score.js
@@ -39,9 +39,6 @@ function score(scoringConfig) {
         const question = scoringConfig.questions.find(
           (q) => q.id === questionId
         )
-        if (!question) {
-          return undefined
-        }
 
         const predicate = question.scoreMethod
         const calculatedScore = predicate(question, responses)

--- a/src/services/scoring/score.test.js
+++ b/src/services/scoring/score.test.js
@@ -22,8 +22,8 @@ describe('score function', () => {
       ],
       maxScore: 8
     },
-    multiScore: {
-      id: 'multiScore',
+    multiAnswer: {
+      id: 'multiAnswer',
       scoreMethod: multiScore,
       category: 'Category 2',
       fundingPriorities: ['Priority B', 'Priority C'],
@@ -44,7 +44,16 @@ describe('score function', () => {
     }
   }
 
-  // const mockScoringConfig = { questions }
+  /**
+   * Generates a mock scoring configuration object based on provided page IDs.
+   * This function creates a scoring configuration object containing
+   * a list of questions associated with the provided page IDs. It
+   * looks up each page's corresponding questions and appends them
+   * to the `questions` property of the scoring configuration object.
+   * @function
+   * @param {...string} pageId - A list of page identifiers used to retrieve associated questions.
+   * @returns {object} A scoring configuration object containing a `questions` array populated based on the provided page IDs.
+   */
   const mockScoringConfig = (...pageId) => {
     const scoringConfig = { questions: [] }
     pageId.forEach((page) => {
@@ -87,13 +96,13 @@ describe('score function', () => {
     ])
   })
 
-  it('returns correct scores for valid multiScore question', () => {
-    const answers = [{ questionId: 'multiScore', answers: ['A', 'B', 'C'] }]
-    const mockConfig = mockScoringConfig('multiScore')
+  it('returns correct scores for valid multiAnswer question', () => {
+    const answers = [{ questionId: 'multiAnswer', answers: ['A', 'B', 'C'] }]
+    const mockConfig = mockScoringConfig('multiAnswer')
     const result = score(mockConfig)(answers)
     expect(result).toEqual([
       {
-        questionId: 'multiScore',
+        questionId: 'multiAnswer',
         category: 'Category 2',
         fundingPriorities: ['Priority B', 'Priority C'],
         score: { value: 10, band: ScoreBands.STRONG }
@@ -119,13 +128,13 @@ describe('score function', () => {
 
   it('handles None of the above correctly for multiAnswer', () => {
     const answers = [
-      { questionId: 'multiScore', answers: ['None of the above'] }
+      { questionId: 'multiAnswer', answers: ['None of the above'] }
     ]
-    const mockConfig = mockScoringConfig('multiScore')
+    const mockConfig = mockScoringConfig('multiAnswer')
     const result = score(mockConfig)(answers)
     expect(result).toEqual([
       {
-        questionId: 'multiScore',
+        questionId: 'multiAnswer',
         category: 'Category 2',
         fundingPriorities: ['Priority B', 'Priority C'],
         score: { value: 0, band: ScoreBands.WEAK }
@@ -135,18 +144,18 @@ describe('score function', () => {
 
   it('throws an error if question ID is not found', () => {
     const answers = [{ questionId: 'invalidQuestion', answers: ['A'] }]
-    const mockConfig = mockScoringConfig('multiScore', 'singleAnswer')
+    const mockConfig = mockScoringConfig('multiAnswer', 'singleAnswer')
     expect(() => score(mockConfig)(answers)).toThrow(
-      'Questions with id(s) multiScore, singleAnswer not found in users answers.'
+      'Questions with id(s) multiAnswer, singleAnswer not found in users answers.'
     )
   })
 
   it('handles multiple answers correctly', () => {
     const answers = [
       { questionId: 'singleAnswer', answers: ['B'] },
-      { questionId: 'multiScore', answers: ['A', 'C'] }
+      { questionId: 'multiAnswer', answers: ['A', 'C'] }
     ]
-    const mockConfig = mockScoringConfig('multiScore', 'singleAnswer')
+    const mockConfig = mockScoringConfig('multiAnswer', 'singleAnswer')
     const result = score(mockConfig)(answers)
     expect(result).toEqual([
       {
@@ -156,7 +165,7 @@ describe('score function', () => {
         score: { value: 8, band: ScoreBands.STRONG }
       },
       {
-        questionId: 'multiScore',
+        questionId: 'multiAnswer',
         category: 'Category 2',
         fundingPriorities: ['Priority B', 'Priority C'],
         score: { value: 6, band: ScoreBands.MEDIUM }

--- a/src/services/scoring/score.test.js
+++ b/src/services/scoring/score.test.js
@@ -4,51 +4,79 @@ import singleScore from './methods/single-score.js'
 import { ScoreBands } from '~/src/config/score-bands.js'
 
 describe('score function', () => {
-  const mockScoringConfig = {
-    questions: [
-      {
-        id: 'singleAnswer',
-        scoreMethod: singleScore,
-        category: 'Category 1',
-        fundingPriorities: ['Priority A'],
-        answers: [
-          { answer: 'A', score: 4 },
-          { answer: 'B', score: 8 },
-          { answer: 'None of the above', score: null }
-        ],
-        scoreBand: [
-          { name: ScoreBands.WEAK, minValue: 0, maxValue: 3 },
-          { name: ScoreBands.MEDIUM, minValue: 4, maxValue: 7 },
-          { name: ScoreBands.STRONG, minValue: 8, maxValue: 8 }
-        ],
-        maxScore: 8
-      },
-      {
-        id: 'multiAnswer',
-        scoreMethod: multiScore,
-        category: 'Category 2',
-        fundingPriorities: ['Priority B', 'Priority C'],
-        answers: [
-          { answer: 'A', score: 4 },
-          { answer: 'B', score: 4 },
-          { answer: 'C', score: 2 },
-          { answer: 'D', score: 2 },
-          { answer: 'E', score: 0 },
-          { answer: 'None of the above', score: null }
-        ],
-        scoreBand: [
-          { name: ScoreBands.WEAK, minValue: 0, maxValue: 4 },
-          { name: ScoreBands.MEDIUM, minValue: 5, maxValue: 8 },
-          { name: ScoreBands.STRONG, minValue: 9, maxValue: 12 }
-        ],
-        maxScore: 12
-      }
-    ]
+  const questions = {
+    singleAnswer: {
+      id: 'singleAnswer',
+      scoreMethod: singleScore,
+      category: 'Category 1',
+      fundingPriorities: ['Priority A'],
+      answers: [
+        { answer: 'A', score: 4 },
+        { answer: 'B', score: 8 },
+        { answer: 'None of the above', score: null }
+      ],
+      scoreBand: [
+        { name: ScoreBands.WEAK, minValue: 0, maxValue: 3 },
+        { name: ScoreBands.MEDIUM, minValue: 4, maxValue: 7 },
+        { name: ScoreBands.STRONG, minValue: 8, maxValue: 8 }
+      ],
+      maxScore: 8
+    },
+    multiScore: {
+      id: 'multiScore',
+      scoreMethod: multiScore,
+      category: 'Category 2',
+      fundingPriorities: ['Priority B', 'Priority C'],
+      answers: [
+        { answer: 'A', score: 4 },
+        { answer: 'B', score: 4 },
+        { answer: 'C', score: 2 },
+        { answer: 'D', score: 2 },
+        { answer: 'E', score: 0 },
+        { answer: 'None of the above', score: null }
+      ],
+      scoreBand: [
+        { name: ScoreBands.WEAK, minValue: 0, maxValue: 4 },
+        { name: ScoreBands.MEDIUM, minValue: 5, maxValue: 8 },
+        { name: ScoreBands.STRONG, minValue: 9, maxValue: 12 }
+      ],
+      maxScore: 12
+    }
   }
+
+  // const mockScoringConfig = { questions }
+  const mockScoringConfig = (...pageId) => {
+    const scoringConfig = { questions: [] }
+    pageId.forEach((page) => {
+      scoringConfig.questions.push(questions[page])
+    })
+    return scoringConfig
+  }
+
+  it('should error when user answers does not include a required question', () => {
+    const answers = [{ questionId: 'not singleAnswer', answers: ['A'] }]
+    const mockConfig = mockScoringConfig('singleAnswer')
+
+    expect(() => score(mockConfig)(answers)).toThrow(
+      'Questions with id(s) singleAnswer not found in users answers.'
+    )
+  })
+
+  it('should ignore questions that are not in the scoring data', () => {
+    const answers = [
+      { questionId: 'singleAnswer', answers: ['A'] },
+      { questionId: 'noScoringQuestion', answers: ['B'] }
+    ]
+    const mockConfig = mockScoringConfig('singleAnswer')
+
+    const result = score(mockConfig)(answers)
+    expect(result).toHaveLength(1)
+  })
 
   it('returns correct scores for valid singleAnswer question', () => {
     const answers = [{ questionId: 'singleAnswer', answers: ['A'] }]
-    const result = score(mockScoringConfig)(answers)
+    const mockConfig = mockScoringConfig('singleAnswer')
+    const result = score(mockConfig)(answers)
     expect(result).toEqual([
       {
         questionId: 'singleAnswer',
@@ -59,12 +87,13 @@ describe('score function', () => {
     ])
   })
 
-  it('returns correct scores for valid multiAnswer question', () => {
-    const answers = [{ questionId: 'multiAnswer', answers: ['A', 'B', 'C'] }]
-    const result = score(mockScoringConfig)(answers)
+  it('returns correct scores for valid multiScore question', () => {
+    const answers = [{ questionId: 'multiScore', answers: ['A', 'B', 'C'] }]
+    const mockConfig = mockScoringConfig('multiScore')
+    const result = score(mockConfig)(answers)
     expect(result).toEqual([
       {
-        questionId: 'multiAnswer',
+        questionId: 'multiScore',
         category: 'Category 2',
         fundingPriorities: ['Priority B', 'Priority C'],
         score: { value: 10, band: ScoreBands.STRONG }
@@ -76,7 +105,8 @@ describe('score function', () => {
     const answers = [
       { questionId: 'singleAnswer', answers: ['None of the above'] }
     ]
-    const result = score(mockScoringConfig)(answers)
+    const mockConfig = mockScoringConfig('singleAnswer')
+    const result = score(mockConfig)(answers)
     expect(result).toEqual([
       {
         questionId: 'singleAnswer',
@@ -89,12 +119,13 @@ describe('score function', () => {
 
   it('handles None of the above correctly for multiAnswer', () => {
     const answers = [
-      { questionId: 'multiAnswer', answers: ['None of the above'] }
+      { questionId: 'multiScore', answers: ['None of the above'] }
     ]
-    const result = score(mockScoringConfig)(answers)
+    const mockConfig = mockScoringConfig('multiScore')
+    const result = score(mockConfig)(answers)
     expect(result).toEqual([
       {
-        questionId: 'multiAnswer',
+        questionId: 'multiScore',
         category: 'Category 2',
         fundingPriorities: ['Priority B', 'Priority C'],
         score: { value: 0, band: ScoreBands.WEAK }
@@ -104,17 +135,19 @@ describe('score function', () => {
 
   it('throws an error if question ID is not found', () => {
     const answers = [{ questionId: 'invalidQuestion', answers: ['A'] }]
-    expect(() => score(mockScoringConfig)(answers)).toThrow(
-      'Question with id invalidQuestion not found in scoringData.'
+    const mockConfig = mockScoringConfig('multiScore', 'singleAnswer')
+    expect(() => score(mockConfig)(answers)).toThrow(
+      'Questions with id(s) multiScore, singleAnswer not found in users answers.'
     )
   })
 
   it('handles multiple answers correctly', () => {
     const answers = [
       { questionId: 'singleAnswer', answers: ['B'] },
-      { questionId: 'multiAnswer', answers: ['A', 'C'] }
+      { questionId: 'multiScore', answers: ['A', 'C'] }
     ]
-    const result = score(mockScoringConfig)(answers)
+    const mockConfig = mockScoringConfig('multiScore', 'singleAnswer')
+    const result = score(mockConfig)(answers)
     expect(result).toEqual([
       {
         questionId: 'singleAnswer',
@@ -123,7 +156,7 @@ describe('score function', () => {
         score: { value: 8, band: ScoreBands.STRONG }
       },
       {
-        questionId: 'multiAnswer',
+        questionId: 'multiScore',
         category: 'Category 2',
         fundingPriorities: ['Priority B', 'Priority C'],
         score: { value: 6, band: ScoreBands.MEDIUM }


### PR DESCRIPTION
This PR allows requests to include questions that are not on the scoring matrix to be sent through the scoring endpoint. They will be ignored.

Any questions that are required by the scoring matrix that are not included in the user request will throw an error.

