### PR TITLE
Scoring service allows partial requests with queryparam <boolean>`allowPartialScoring`

### DIFF
--- a/src/api/scoring/handler.js
+++ b/src/api/scoring/handler.js
@@ -60,11 +60,14 @@ export const handler = (request, h) => {
 }
 
 const toBool = (value) => {
+  const checkForStrings =
+    typeof value === 'string' &&
+    (value.toLowerCase() === 'true' ||
+      value !== 'false' ||
+      parseInt(value) >= 1)
+
   return (
-    (typeof value === 'string' &&
-      (value.toLowerCase() === 'true' ||
-        value !== 'false' ||
-        parseInt(value) < 1)) ||
+    checkForStrings ||
     (typeof value === 'number' && value >= 1) ||
     (typeof value === 'boolean' && value === true)
   )

--- a/src/api/scoring/handler.js
+++ b/src/api/scoring/handler.js
@@ -12,7 +12,7 @@ export const handler = (request, h) => {
   })
   const scoringConfig = getScoringConfig(grantType)
 
-  const options = {
+  const scoringOptions = {
     allowPartialScoring:
       request.query && Object.hasOwn(request.query, 'allowPartialScoring')
         ? Boolean(request.query.allowPartialScoring)
@@ -37,7 +37,7 @@ export const handler = (request, h) => {
     // Extract user answers directly
     const answers = request.payload.data.main
     // Find matching scoring data for the provided questionIds
-    const rawScores = score(scoringConfig, options)(answers)
+    const rawScores = score(scoringConfig, scoringOptions)(answers)
     const finalResult = mapToFinalResult(scoringConfig, rawScores)
     log(LogCodes.SCORING.FINAL_RESULT, {
       grantType,

--- a/src/api/scoring/handler.js
+++ b/src/api/scoring/handler.js
@@ -15,7 +15,7 @@ export const handler = (request, h) => {
   const scoringOptions = {
     allowPartialScoring:
       request.query && Object.hasOwn(request.query, 'allowPartialScoring')
-        ? Boolean(request.query.allowPartialScoring)
+        ? toBool(request.query.allowPartialScoring)
         : false
   }
 
@@ -57,4 +57,15 @@ export const handler = (request, h) => {
       })
       .code(statusCodes.badRequest)
   }
+}
+
+const toBool = (value) => {
+  return (
+    (typeof value === 'string' &&
+      (value.toLowerCase() === 'true' ||
+        value !== 'false' ||
+        parseInt(value) < 1)) ||
+    (typeof value === 'number' && value >= 1) ||
+    (typeof value === 'boolean' && value === true)
+  )
 }

--- a/src/api/scoring/handler.js
+++ b/src/api/scoring/handler.js
@@ -12,6 +12,13 @@ export const handler = (request, h) => {
   })
   const scoringConfig = getScoringConfig(grantType)
 
+  const options = {
+    allowPartialScoring:
+      request.query && Object.hasOwn(request.query, 'allowPartialScoring')
+        ? Boolean(request.query.allowPartialScoring)
+        : false
+  }
+
   if (!scoringConfig) {
     log(LogCodes.SCORING.CONFIG_MISSING, {
       grantType,
@@ -30,7 +37,7 @@ export const handler = (request, h) => {
     // Extract user answers directly
     const answers = request.payload.data.main
     // Find matching scoring data for the provided questionIds
-    const rawScores = score(scoringConfig)(answers)
+    const rawScores = score(scoringConfig, options)(answers)
     const finalResult = mapToFinalResult(scoringConfig, rawScores)
     log(LogCodes.SCORING.FINAL_RESULT, {
       grantType,

--- a/src/api/scoring/handler.test.js
+++ b/src/api/scoring/handler.test.js
@@ -77,6 +77,34 @@ describe('Handler Function', () => {
     expect(mockH.code).toHaveBeenCalledWith(400)
   })
 
+  it.each([
+    { test: true, expected: true },
+    { test: false, expected: false },
+    { test: 'true', expected: true },
+    { test: 'false', expected: false },
+    { test: 'test', expected: true },
+    { test: '', expected: true },
+    { test: 1, expected: true },
+    { test: 0, expected: false },
+    { test: undefined, expected: false },
+    { test: null, expected: false }
+  ])(
+    `with queryParam of $test it should pass { allowPartialScoring: $expected } to the score function`,
+    async ({ test, expected }) => {
+      getScoringConfig.mockReturnValue(mockScoringConfig)
+      score.mockImplementation(() => (_answers) => mockRawScores)
+      mapToFinalResult.mockReturnValue(mockFinalResult)
+
+      const request = mockRequest('example-grant')
+      request.query = { allowPartialScoring: test }
+      await handler(request, mockH)
+
+      expect(score).toHaveBeenCalledWith(mockScoringConfig, {
+        allowPartialScoring: expected
+      })
+    }
+  )
+
   it('should process valid grant type and return final result', async () => {
     getScoringConfig.mockReturnValue(mockScoringConfig)
     score.mockImplementation(() => (_answers) => mockRawScores)

--- a/src/api/scoring/handler.test.js
+++ b/src/api/scoring/handler.test.js
@@ -99,7 +99,9 @@ describe('Handler Function', () => {
     )
 
     expect(getScoringConfig).toHaveBeenCalledWith('example-grant')
-    expect(score).toHaveBeenCalledWith(mockScoringConfig)
+    expect(score).toHaveBeenCalledWith(mockScoringConfig, {
+      allowPartialScoring: false
+    })
     expect(score(mockScoringConfig)).toBeInstanceOf(Function)
     expect(score(mockScoringConfig)(mockAnswers)).toEqual(mockRawScores)
 

--- a/src/api/scoring/index.js
+++ b/src/api/scoring/index.js
@@ -1,4 +1,4 @@
-import { scoringPayloadSchema } from './validation.js'
+import { scoringPayloadSchema, scoringQueryParamsSchema } from './validation.js'
 import { scoringController } from '~/src/api/scoring/controller.js'
 import { scoringFailAction } from './fail-action.js'
 
@@ -15,6 +15,7 @@ const scoring = {
         ...scoringController,
         options: {
           validate: {
+            query: scoringQueryParamsSchema,
             payload: scoringPayloadSchema,
             failAction: scoringFailAction
           }

--- a/src/api/scoring/validation.js
+++ b/src/api/scoring/validation.js
@@ -1,5 +1,9 @@
 import Joi from 'joi'
 
+export const scoringQueryParamsSchema = Joi.object({
+  allowPartialScoring: Joi.boolean().default(false)
+})
+
 export const scoringPayloadSchema = Joi.object({
   meta: Joi.any(),
   data: Joi.object({

--- a/src/api/scoring/validation.test.js
+++ b/src/api/scoring/validation.test.js
@@ -1,4 +1,18 @@
-import { scoringPayloadSchema } from './validation.js'
+import { scoringPayloadSchema, scoringQueryParamsSchema } from './validation.js'
+
+describe('Scoring query params validation', () => {
+  it('should default to false if query is not provided', () => {
+    const request = {}
+    const result = scoringQueryParamsSchema.validate(request)
+    expect(result.value.allowPartialScoring).toBe(false)
+  })
+
+  it('should allow partial scoring if query is true', () => {
+    const query = { allowPartialScoring: true }
+    const result = scoringQueryParamsSchema.validate(query)
+    expect(result.value.allowPartialScoring).toBe(true)
+  })
+})
 
 describe('Scoring Payload Validation', () => {
   describe('valid', () => {

--- a/src/services/scoring/methods/multi-score.js
+++ b/src/services/scoring/methods/multi-score.js
@@ -7,6 +7,7 @@
  * @throws {Error} Throws if none of the `userAnswers` are found in the scoring rules.
  */
 function multiScore(questionScoringConfig, userAnswers) {
+  // @todo this code is nasty, if it remains in the repo it needs to be moved to middleware. Ideally we should never need this once DXT has completed their work.
   if (userAnswers.length === 1) {
     userAnswers = userAnswers[0].split(',')
   }

--- a/src/services/scoring/methods/multi-score.js
+++ b/src/services/scoring/methods/multi-score.js
@@ -9,7 +9,7 @@
 function multiScore(questionScoringConfig, userAnswers) {
   // @todo this code is nasty, if it remains in the repo it needs to be moved to middleware. Ideally we should never need this once DXT has completed their work.
   if (userAnswers.length === 1) {
-    userAnswers = userAnswers[0].split(',')
+    userAnswers = [...new Set(userAnswers[0].split(','))]
   }
 
   const scores = userAnswers.map((userAnswer) => {

--- a/src/services/scoring/methods/multi-score.js
+++ b/src/services/scoring/methods/multi-score.js
@@ -7,6 +7,10 @@
  * @throws {Error} Throws if none of the `userAnswers` are found in the scoring rules.
  */
 function multiScore(questionScoringConfig, userAnswers) {
+  if (userAnswers.length === 1) {
+    userAnswers = userAnswers[0].split(',')
+  }
+
   const scores = userAnswers.map((userAnswer) => {
     const matchingAnswer = questionScoringConfig.answers.find(
       (answer) => answer.answer === userAnswer

--- a/src/services/scoring/score.js
+++ b/src/services/scoring/score.js
@@ -48,10 +48,11 @@ function scoreAnswers(filteredAnswers, questionMap) {
 /**
  * Calculates and evaluates the score based on provided scoring data and answers.
  * @param {import("~/src/config/scoring-types.js").ScoringConfig} scoringConfig - The scoring data.
+ * @param {{ allowPartialScoring: Boolean } [Object]} - Scoring options
  * @returns {Function} A function that takes user answers and returns an array of scored results.
  * @throws {Error} If required questions are missing from user answers.
  */
-function score(scoringConfig) {
+function score(scoringConfig, options = {}) {
   const questionMap = new Map(scoringConfig.questions.map((q) => [q.id, q]))
   const scoringConfigQuestionIds = new Set(questionMap.keys())
 
@@ -60,15 +61,18 @@ function score(scoringConfig) {
       userAnswers,
       scoringConfigQuestionIds
     )
-    const missingQuestions = findMissingQuestions(
-      filteredAnswers,
-      scoringConfigQuestionIds
-    )
 
-    if (missingQuestions.length > 0) {
-      throw new Error(
-        `Questions with id(s) ${missingQuestions.join(', ')} not found in user's answers.`
+    if (!options.allowPartialScoring) {
+      const missingQuestions = findMissingQuestions(
+        filteredAnswers,
+        scoringConfigQuestionIds
       )
+
+      if (missingQuestions.length > 0) {
+        throw new Error(
+          `Questions with id(s) ${missingQuestions.join(', ')} not found in user's answers.`
+        )
+      }
     }
 
     return scoreAnswers(filteredAnswers, questionMap)

--- a/src/services/scoring/score.js
+++ b/src/services/scoring/score.js
@@ -48,11 +48,11 @@ function scoreAnswers(filteredAnswers, questionMap) {
 /**
  * Calculates and evaluates the score based on provided scoring data and answers.
  * @param {import("~/src/config/scoring-types.js").ScoringConfig} scoringConfig - The scoring data.
- * @param {{ allowPartialScoring: boolean }} [options] - Optional configuration.
+ * @param {boolean} allowPartialScoring - Whether to allow partial scoring.
  * @returns {Function} A function that takes user answers and returns an array of scored results.
  * @throws {Error} If required questions are missing from user answers.
  */
-function score(scoringConfig, options = {}) {
+function score(scoringConfig, allowPartialScoring) {
   const questionMap = new Map(scoringConfig.questions.map((q) => [q.id, q]))
   const scoringConfigQuestionIds = new Set(questionMap.keys())
 
@@ -62,7 +62,7 @@ function score(scoringConfig, options = {}) {
       scoringConfigQuestionIds
     )
 
-    if (!options.allowPartialScoring) {
+    if (!allowPartialScoring) {
       const missingQuestions = findMissingQuestions(
         filteredAnswers,
         scoringConfigQuestionIds

--- a/src/services/scoring/score.js
+++ b/src/services/scoring/score.js
@@ -48,7 +48,7 @@ function scoreAnswers(filteredAnswers, questionMap) {
 /**
  * Calculates and evaluates the score based on provided scoring data and answers.
  * @param {import("~/src/config/scoring-types.js").ScoringConfig} scoringConfig - The scoring data.
- * @param {{ allowPartialScoring: Boolean } [Object]} - Scoring options
+ * @param {{ allowPartialScoring: boolean }} [options] - Optional configuration.
  * @returns {Function} A function that takes user answers and returns an array of scored results.
  * @throws {Error} If required questions are missing from user answers.
  */

--- a/src/services/scoring/score.test.js
+++ b/src/services/scoring/score.test.js
@@ -56,18 +56,16 @@ describe('score function', () => {
     const answers = { 'not singleAnswer': ['A'] }
     const mockConfig = mockScoringConfig('singleAnswer')
 
-    expect(() =>
-      score(mockConfig, { allowPartialScoring: false })(answers)
-    ).toThrow(`Questions with id(s) singleAnswer not found in user's answers.`)
+    expect(() => score(mockConfig, false)(answers)).toThrow(
+      `Questions with id(s) singleAnswer not found in user's answers.`
+    )
   })
 
   it('should not error when user answers do not include required questions and allowPartialScoring is enabled', () => {
     const answers = { singleAnswer: ['A'] }
     const mockConfig = mockScoringConfig('singleAnswer', 'multiAnswer')
 
-    expect(() =>
-      score(mockConfig, { allowPartialScoring: true })(answers)
-    ).not.toThrow()
+    expect(() => score(mockConfig, true)(answers)).not.toThrow()
   })
 
   it('should ignore questions that are not in the scoring data', () => {

--- a/src/services/scoring/score.test.js
+++ b/src/services/scoring/score.test.js
@@ -61,6 +61,15 @@ describe('score function', () => {
     )
   })
 
+  it('should not error when user answers do not include required questions and allowPartialScoring is enabled', () => {
+    const answers = { singleAnswer: ['A'] }
+    const mockConfig = mockScoringConfig('singleAnswer', 'multiAnswer')
+
+    expect(() => score(mockConfig)(answers)).not.toThrow(
+      `Questions with id(s) singleAnswer not found in user's answers.`
+    )
+  })
+
   it('should ignore questions that are not in the scoring data', () => {
     const answers = {
       singleAnswer: ['A'],

--- a/src/services/scoring/score.test.js
+++ b/src/services/scoring/score.test.js
@@ -56,18 +56,18 @@ describe('score function', () => {
     const answers = { 'not singleAnswer': ['A'] }
     const mockConfig = mockScoringConfig('singleAnswer')
 
-    expect(() => score(mockConfig)(answers)).toThrow(
-      `Questions with id(s) singleAnswer not found in user's answers.`
-    )
+    expect(() =>
+      score(mockConfig, { allowPartialScoring: false })(answers)
+    ).toThrow(`Questions with id(s) singleAnswer not found in user's answers.`)
   })
 
   it('should not error when user answers do not include required questions and allowPartialScoring is enabled', () => {
     const answers = { singleAnswer: ['A'] }
     const mockConfig = mockScoringConfig('singleAnswer', 'multiAnswer')
 
-    expect(() => score(mockConfig)(answers)).not.toThrow(
-      `Questions with id(s) singleAnswer not found in user's answers.`
-    )
+    expect(() =>
+      score(mockConfig, { allowPartialScoring: true })(answers)
+    ).not.toThrow()
   })
 
   it('should ignore questions that are not in the scoring data', () => {


### PR DESCRIPTION
Calling the service with a query parameter of `allowPartialScoring` will enable / disable checking whether all scoring questions are in the request.