### PR TITLE
reverting logging functionality, made all message interpolation based…

### DIFF
--- a/src/api/logging/log-code-validator.js
+++ b/src/api/logging/log-code-validator.js
@@ -1,0 +1,88 @@
+import Joi from 'joi'
+import { isStrictObject } from '../../utils/isStrictObject.js'
+
+class LogLevel {
+  static info = new LogLevel('info')
+  static error = new LogLevel('error')
+  static debug = new LogLevel('debug')
+
+  constructor(name) {
+    this.name = name
+  }
+}
+
+export const validateLogCode = (logCode, messageOptions = null) => {
+  if (!isStrictObject(logCode, true)) {
+    throw new Error('logCode must be a non-empty object')
+  }
+
+  const { error } = Joi.object({
+    level: Joi.string().valid(...Object.keys(LogLevel)),
+    messageFunc: Joi.function()
+  }).validate(logCode)
+
+  if (error) throw new Error(error.message)
+
+  validateInterpolation(logCode, messageOptions)
+}
+
+function validateInterpolation(logCode, messageOptions) {
+  const funcString = logCode.messageFunc.toString()
+  const isInterpolatedString =
+    /\.concat/.test(funcString) || /\${messageOptions/.test(funcString)
+
+  if (!isInterpolatedString && messageOptions)
+    throw new Error(
+      'If you have message options you must have an interpolated string'
+    )
+
+  if (isInterpolatedString) {
+    if (!messageOptions) {
+      throw new Error(
+        'If you have interpolated string values you must have message options'
+      )
+    }
+
+    const messageOptionsKeys = getKeys(messageOptions)
+    const interpolatedKeys = getInterpolations(funcString)
+
+    if (
+      !interpolatedKeys.every((value) => messageOptionsKeys.includes(value))
+    ) {
+      throw new Error('String interpolation values must match messageOptions')
+    }
+  }
+
+  return true
+}
+
+const getKeys = (obj, prefix = '') => {
+  return Object.entries(obj).flatMap(([key, value]) => {
+    const newKey = prefix ? `${prefix}.${key}` : key
+
+    return typeof value !== 'object'
+      ? [`messageOptions.${newKey}`]
+      : getKeys(value, newKey)
+  })
+}
+
+const getInterpolations = (str) => {
+  const regexConcat = /\.concat\(([^)]+)\)/g
+  const regexMessageOptions = /\$\{messageOptions((?:\.\w+)+)\}/g
+
+  const concatMatches = [...str.matchAll(regexConcat)]
+  const messageOptionsMatches = [...str.matchAll(regexMessageOptions)]
+
+  const extractedConcat = concatMatches.flatMap((match) =>
+    [...match[1].matchAll(/messageOptions((?:\.\w+)+)/g)].map(
+      (m) => `messageOptions${m[1]}`
+    )
+  )
+
+  const extractedTemplate = messageOptionsMatches.map(
+    // istanbul ignore next
+    (match) => `messageOptions${match[1]}`
+  )
+
+  return [...extractedConcat, ...extractedTemplate]
+}

--- a/src/api/logging/log-codes.js
+++ b/src/api/logging/log-codes.js
@@ -2,29 +2,33 @@ export const LogCodes = {
   SCORING: {
     REQUEST_RECEIVED: {
       level: 'info',
-      event: 'scoring_request_received'
+      messageFunc: (messageOptions) =>
+        `Request received for grantType=${messageOptions.grantType}`
     },
     CONFIG_MISSING: {
       level: 'error',
-      event: 'scoring_config_missing'
+      messageFunc: (messageOptions) =>
+        `Scoring config missing for grantType=${messageOptions.grantType}`
     },
     CONFIG_FOUND: {
       level: 'info',
-      event: 'scoring_config_found'
+      messageFunc: (messageOptions) =>
+        `Scoring config found for grantType=${messageOptions.grantType}`
     },
     FINAL_RESULT: {
       level: 'info',
-      event: 'scoring_final_result'
+      messageFunc: (messageOptions) =>
+        `Scoring final result for grantType=${messageOptions.grantType}. Score=${messageOptions.finalResult.score}. Band=${messageOptions.finalResult.scoreBand}. Eligibility=${messageOptions.finalResult.status}`
     },
     CONVERSION_ERROR: {
       level: 'error',
-      event: 'scoring_conversion_error'
+      messageFunc: (messageOptions) =>
+        `Scoring conversion error for grantType=${messageOptions.grantType}. Error: ${messageOptions.error}`
     },
     VALIDATION_ERROR: {
       level: 'error',
-      event: 'scoring_validation_error'
+      messageFunc: (messageOptions) =>
+        `Validation Error for grantType=${messageOptions.grantType} with message(s): ${messageOptions.messages.join(' | ')}`
     }
   }
 }
-
-export const LogCodeLevels = ['info', 'error', 'debug']

--- a/src/api/logging/log.js
+++ b/src/api/logging/log.js
@@ -1,5 +1,6 @@
 import { createLogger } from '../common/helpers/logging/logger.js'
-import { LogCodes, LogCodeLevels } from './log-codes.js'
+import { LogCodes } from './log-codes.js'
+import { validateLogCode } from './log-code-validator.js'
 
 const logger = createLogger()
 
@@ -10,67 +11,28 @@ const logger = createLogger()
 
 /**
  * Logs an event with the specified level and context.
- * @param {object} options - Logging options.
- * @param {LogLevel} options.level - The log level.
- * @param {LogEvent} options.event - The log event.
- * @param {object} [context] - Additional context for the log.
+ * @param {object} logCode - Logging options.
+ * @param {string} logCode.level - The log level.
+ * @param {Function} logCode.messageFunc - A function that creates an interpolated message string
+ * @param {object} messageOptions - Values for message interpolation
  * @throws {Error} If log parameters are invalid.
  */
-const log = ({ level, event } = {}, context = {}) => {
-  validateLogParams({ level, event }, context)
-
-  // Call the appropriate logger function with the provided context
-  getLoggerOfType(level)({
-    event,
-    ...context
-  })
+const log = (logCode, messageOptions) => {
+  validateLogCode(logCode, messageOptions)
+  getLoggerOfType(logCode.level)(logCode.messageFunc(messageOptions))
 }
 
 /**
  * Returns the logger function corresponding to the given log level.
- * @param {LogLevel} type - The log level.
+ * @param {string} level - The log level.
  * @returns {(context: object) => void} Logger function.
  */
-const getLoggerOfType = (type) => {
+const getLoggerOfType = (level) => {
   return {
-    info: (context) => logger.info(context),
-    debug: (context) => logger.debug(context),
-    error: (context) => logger.error(context)
-  }[type]
-}
-
-/**
- * Validates logging parameters.
- * @param {object} params - The log parameters.
- * @param {LogLevel} params.level - The log level.
- * @param {LogEvent} params.event - The log event.
- * @param {object} context - Additional context.
- * @throws {Error} If parameters are invalid.
- */
-const validateLogParams = ({ level, event }, context) => {
-  if (level === undefined && event === undefined) {
-    throw new Error('Invalid log configuration: Missing or invalid logCode')
-  }
-
-  if (!LogCodeLevels.includes(level)) {
-    throw new Error('Invalid log configuration: Invalid logCode level')
-  }
-
-  const validationErrors = {
-    level: !level,
-    event: !event,
-    context: typeof context !== 'object' || Array.isArray(context)
-  }
-
-  const invalidField = Object.keys(validationErrors).find(
-    (key) => validationErrors[key]
-  )
-
-  if (invalidField) {
-    throw new Error(
-      `Invalid log configuration: Missing or invalid ${invalidField}`
-    )
-  }
+    info: (message) => logger.info(message),
+    debug: (message) => logger.debug(message),
+    error: (message) => logger.error(message)
+  }[level]
 }
 
 export { log, LogCodes, logger }

--- a/src/api/scoring/fail-action.js
+++ b/src/api/scoring/fail-action.js
@@ -1,5 +1,5 @@
 import { statusCodes } from '../common/constants/status-codes.js'
-import { logger } from '../logging/log.js'
+import { log, LogCodes } from '../logging/log.js'
 
 export const scoringFailAction = (_request, h, err) => {
   if (err.isJoi) {
@@ -21,7 +21,9 @@ export const scoringFailAction = (_request, h, err) => {
 
     const message = `Validation failed: ${messages.join(' | ')}`
 
-    logger.error(message)
+    log(LogCodes.SCORING.VALIDATION_ERROR, {
+      grantType: _request.params.grantType
+    })
     return h
       .response({
         statusCode: statusCodes.badRequest,

--- a/src/api/scoring/fail-action.test.js
+++ b/src/api/scoring/fail-action.test.js
@@ -1,6 +1,5 @@
 import { scoringFailAction } from './fail-action.js'
 import { statusCodes } from '../common/constants/status-codes.js'
-// import { log } from '../logging/log.js'
 
 // Mock the logger to avoid actual logging during tests
 jest.mock('../logging/log.js')
@@ -42,15 +41,6 @@ describe('scoringFailAction', () => {
     expect(response).toBe(h)
     expect(h.code).toHaveBeenCalledWith(statusCodes.badRequest)
     expect(h.takeover).toHaveBeenCalled()
-    // expect(log).toHaveBeenCalledWith(
-    //   {
-    //     event: 'scoring_validation_error',
-    //     level: 'error'
-    //   },
-    //   {
-    //     message: 'Validation failed: [field1]: "field1" is required'
-    //   }
-    // )
   })
 
   test('should return bad request response with multiple validation errors', () => {
@@ -84,16 +74,6 @@ describe('scoringFailAction', () => {
     expect(response).toBe(h)
     expect(h.code).toHaveBeenCalledWith(statusCodes.badRequest)
     expect(h.takeover).toHaveBeenCalled()
-    // expect(log).toHaveBeenCalledWith(
-    //   {
-    //     event: 'scoring_validation_error',
-    //     level: 'error'
-    //   },
-    //   {
-    //     message:
-    //       'Validation failed: [field1]: "field1" is required | [field2]: "field2" must be a number'
-    //   }
-    // )
   })
 
   test('should return bad request response when there is no context.details', () => {
@@ -121,15 +101,6 @@ describe('scoringFailAction', () => {
     expect(response).toBe(h)
     expect(h.code).toHaveBeenCalledWith(statusCodes.badRequest)
     expect(h.takeover).toHaveBeenCalled()
-    // expect(log).toHaveBeenCalledWith(
-    //   {
-    //     event: 'scoring_validation_error',
-    //     level: 'error'
-    //   },
-    //   {
-    //     message: 'Validation failed: [field1]: "field1" is required'
-    //   }
-    // )
   })
 
   test('should handle context.details and return formatted message', () => {
@@ -169,16 +140,6 @@ describe('scoringFailAction', () => {
     expect(response).toBe(h)
     expect(h.code).toHaveBeenCalledWith(statusCodes.badRequest)
     expect(h.takeover).toHaveBeenCalled()
-    // expect(log).toHaveBeenCalledWith(
-    //   {
-    //     event: 'scoring_validation_error',
-    //     level: 'error'
-    //   },
-    //   {
-    //     message:
-    //       'Validation failed: [field1.subfield1]: "subfield1" is required, [field1.subfield2]: "subfield2" must be a number'
-    //   }
-    // )
   })
 
   test('should re-throw error if not Joi validation error', () => {

--- a/src/api/scoring/handler.test.js
+++ b/src/api/scoring/handler.test.js
@@ -3,7 +3,7 @@ import { handler } from './handler.js'
 import { getScoringConfig } from '../../config/scoring-config.js'
 import mapToFinalResult from './mapper/map-to-final-result.js'
 import score from '../../../src/services/scoring/score.js'
-// import { log, LogCodes } from '../logging/log.js'
+import { log, LogCodes } from '../logging/log.js'
 
 jest.mock('../../config/scoring-config.js')
 jest.mock('./mapper/map-to-final-result.js', () => ({
@@ -103,12 +103,9 @@ describe('Handler Function', () => {
 
     await handler(mockRequest('example-grant'), mockH)
 
-    // expect(log).toHaveBeenCalledWith(
-    //   LogCodes.SCORING.REQUEST_RECEIVED,
-    //   expect.objectContaining({
-    //     message: `Request received for grantType=example-grant`
-    //   })
-    // )
+    expect(log).toHaveBeenCalledWith(LogCodes.SCORING.REQUEST_RECEIVED, {
+      grantType: 'example-grant'
+    })
 
     // expect(log).toHaveBeenCalledWith(
     //   LogCodes.SCORING.CONFIG_FOUND,
@@ -127,14 +124,10 @@ describe('Handler Function', () => {
       mockRawScores
     )
 
-    // expect(log).toHaveBeenCalledWith(
-    //   LogCodes.SCORING.FINAL_RESULT,
-    //   expect.objectContaining({
-    //     message: expect.stringContaining(
-    //       'Score=8. Band=Medium. Eligibility=eligible'
-    //     )
-    //   })
-    // )
+    expect(log).toHaveBeenCalledWith(LogCodes.SCORING.FINAL_RESULT, {
+      finalResult: { score: 8, scoreBand: 'Medium', status: 'eligible' },
+      grantType: 'example-grant'
+    })
 
     expect(mockH.response).toHaveBeenCalledWith(mockFinalResult)
     expect(mockH.code).toHaveBeenCalledWith(200)
@@ -150,12 +143,18 @@ describe('Handler Function', () => {
 
     await handler(mockRequest('example-grant'), mockH)
 
-    // expect(log).toHaveBeenCalledWith(
-    //   LogCodes.SCORING.CONVERSION_ERROR,
-    //   expect.objectContaining({
-    //     message: errorMessage
-    //   })
-    // )
+    expect(log).toHaveBeenCalledWith(LogCodes.SCORING.REQUEST_RECEIVED, {
+      grantType: 'example-grant'
+    })
+
+    expect(log).toHaveBeenCalledWith(LogCodes.SCORING.CONFIG_FOUND, {
+      grantType: 'example-grant'
+    })
+
+    expect(log).toHaveBeenCalledWith(LogCodes.SCORING.CONVERSION_ERROR, {
+      grantType: 'example-grant',
+      error: 'The score function threw an error.'
+    })
 
     expect(mockH.response).toHaveBeenCalledWith({
       statusCode: 400,
@@ -176,12 +175,18 @@ describe('Handler Function', () => {
 
     await handler(mockRequest('example-grant'), mockH)
 
-    // expect(log).toHaveBeenCalledWith(
-    //   LogCodes.SCORING.CONVERSION_ERROR,
-    //   expect.objectContaining({
-    //     message: errorMessage
-    //   })
-    // )
+    expect(log).toHaveBeenCalledWith(LogCodes.SCORING.REQUEST_RECEIVED, {
+      grantType: 'example-grant'
+    })
+
+    expect(log).toHaveBeenCalledWith(LogCodes.SCORING.CONFIG_FOUND, {
+      grantType: 'example-grant'
+    })
+
+    expect(log).toHaveBeenCalledWith(LogCodes.SCORING.CONVERSION_ERROR, {
+      grantType: 'example-grant',
+      error: 'mapToFinalResult threw an error.'
+    })
 
     expect(mockH.response).toHaveBeenCalledWith({
       statusCode: 400,

--- a/src/utils/isStrictObject.js
+++ b/src/utils/isStrictObject.js
@@ -1,0 +1,8 @@
+export const isStrictObject = (value, checkIfEmpty = false) => {
+  const isObject = Object.prototype.toString.call(value) === '[object Object]'
+
+  if (!isObject) return false
+  if (checkIfEmpty) if (!Object.keys(value).length) return false
+
+  return true
+}

--- a/src/utils/isStrictObject.test.js
+++ b/src/utils/isStrictObject.test.js
@@ -1,0 +1,38 @@
+import { isStrictObject } from './isStrictObject.js'
+
+describe('isStrictObject', () => {
+  it('returns true for plain objects', () => {
+    expect(isStrictObject({ key: 'value' })).toBe(true)
+  })
+
+  it('returns false for arrays', () => {
+    expect(isStrictObject([])).toBe(false)
+    expect(isStrictObject([1, 2, 3])).toBe(false)
+  })
+
+  it('returns false for null', () => {
+    expect(isStrictObject(null)).toBe(false)
+  })
+
+  it('returns false for primitive types', () => {
+    expect(isStrictObject(42)).toBe(false)
+    expect(isStrictObject('string')).toBe(false)
+    expect(isStrictObject(true)).toBe(false)
+    expect(isStrictObject(undefined)).toBe(false)
+    expect(isStrictObject(Symbol('test'))).toBe(false)
+  })
+
+  it('returns false for functions', () => {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    expect(isStrictObject(() => {})).toBe(false)
+  })
+
+  it('returns false for undefined', () => {
+    expect(isStrictObject(undefined)).toBe(false)
+  })
+
+  it('handles the optional checkIfEmpty flag', () => {
+    expect(isStrictObject({}, false)).toBe(true)
+    expect(isStrictObject({}, true)).toBe(false)
+  })
+})


### PR DESCRIPTION
Moves logging to a system of using LogCodes to save messages and dynamically interpolate messages with values.

Both the logging system and the interpolation is validated.

Have fixed some existing tests that had logging as part of their testing.