### PR TITLE
Move logging validation to startup

### DIFF
--- a/src/api/logging/log-codes.js
+++ b/src/api/logging/log-codes.js
@@ -1,5 +1,7 @@
 // istanbul ignore file
 
+import { validateLogCode } from './log-code-validator.js'
+
 export const LogCodes = {
   SCORING: {
     REQUEST_RECEIVED: {
@@ -34,3 +36,30 @@ export const LogCodes = {
     }
   }
 }
+
+// Validate all log codes once at startup
+export const validateLogCodes = (logCodes) => {
+  Object.values(logCodes).forEach((entry) => {
+    Object.entries(entry).forEach(([key, value]) => {
+      if (value === null || value === undefined) {
+        throw new Error('logCode must be a non-empty object')
+      }
+      if ('level' in value && 'messageFunc' in value) {
+        try {
+          validateLogCode(value)
+        } catch (e) {
+          throw new Error(
+            `Invalid log code definition for "${key}": ${e.message}`
+          )
+        }
+      } else {
+        throw new Error(
+          `Invalid log code definition for "${key}": Missing "level" or "messageFunc"`
+        )
+      }
+    })
+  })
+}
+
+// Run validation on all log codes
+validateLogCodes(LogCodes)

--- a/src/api/logging/log-codes.js
+++ b/src/api/logging/log-codes.js
@@ -1,5 +1,3 @@
-// istanbul ignore file
-
 import { validateLogCode } from './log-code-validator.js'
 
 export const LogCodes = {

--- a/src/api/logging/log-codes.test.js
+++ b/src/api/logging/log-codes.test.js
@@ -1,4 +1,4 @@
-import { LogCodes } from './log-codes.js'
+import { LogCodes, validateLogCodes } from './log-codes.js'
 
 describe('LogCodes', () => {
   const grantType = 'testGrant'
@@ -50,5 +50,78 @@ describe('LogCodes', () => {
     expect(LogCodes.SCORING.VALIDATION_ERROR.messageFunc(messageOptions)).toBe(
       `Validation Error for grantType=${grantType} with message(s): Field is required`
     )
+  })
+
+  describe('validateLogCodes', () => {
+    it('should validate all log codes without error for valid log codes', () => {
+      expect(() => validateLogCodes(LogCodes)).not.toThrow()
+    })
+
+    it('should throw an error if a log code is missing "level"', () => {
+      const invalidLogCodes = {
+        SCORING: {
+          INVALID_LOG: {
+            messageFunc: () => 'This is an invalid log'
+          }
+        }
+      }
+
+      expect(() => validateLogCodes(invalidLogCodes)).toThrow(
+        `Invalid log code definition for "INVALID_LOG": Missing "level" or "messageFunc"`
+      )
+    })
+
+    it('should throw an error if a log code is missing "messageFunc"', () => {
+      const invalidLogCodes = {
+        SCORING: {
+          INVALID_LOG: {
+            level: 'error'
+          }
+        }
+      }
+
+      expect(() => validateLogCodes(invalidLogCodes)).toThrow(
+        'Invalid log code definition for "INVALID_LOG": Missing "level" or "messageFunc"'
+      )
+    })
+
+    it('should throw an error if logCode level is invalid', () => {
+      const invalidLogCodeLevel = {
+        SCORING: {
+          INVALID_LOG: {
+            level: 'invalidLogLevel',
+            messageFunc: () => 'This is a message func'
+          }
+        }
+      }
+      expect(() => validateLogCodes(invalidLogCodeLevel)).toThrow(
+        'Invalid log level'
+      )
+    })
+
+    it('should throw an error if logCode is not an object', () => {
+      const logCodeNotAnObject = {
+        SCORING: {
+          INVALID_LOG: null
+        }
+      }
+      expect(() => validateLogCodes(logCodeNotAnObject)).toThrow(
+        'logCode must be a non-empty object'
+      )
+    })
+
+    it('should throw an error if messageFunc is not a function', () => {
+      const logCodeNotAnObject = {
+        SCORING: {
+          INVALID_LOG: {
+            level: 'info',
+            messageFunc: 'not-a-function'
+          }
+        }
+      }
+      expect(() => validateLogCodes(logCodeNotAnObject)).toThrow(
+        'logCode.messageFunc must be a function'
+      )
+    })
   })
 })

--- a/src/api/logging/log.js
+++ b/src/api/logging/log.js
@@ -1,6 +1,5 @@
 import { createLogger } from '../common/helpers/logging/logger.js'
 import { LogCodes } from './log-codes.js'
-import { validateLogCode } from './log-code-validator.js'
 
 const logger = createLogger()
 
@@ -17,7 +16,6 @@ const logger = createLogger()
  * @throws {Error} If log parameters are invalid.
  */
 const log = (logCode, messageOptions) => {
-  validateLogCode(logCode)
   getLoggerOfType(logCode.level)(logCode.messageFunc(messageOptions))
 }
 

--- a/src/api/logging/log.test.js
+++ b/src/api/logging/log.test.js
@@ -31,110 +31,68 @@ describe('Logger Functionality', () => {
     jest.clearAllMocks()
   })
 
-  describe('Valid Logging Scenarios', () => {
-    it('Should call the info logger with the correct interpolated message', () => {
-      log(mockLogCode, messageOptions)
+  it('Should call the info logger with the correct interpolated message', () => {
+    log(mockLogCode, messageOptions)
 
-      expect(mockInfoLogger).toHaveBeenCalledWith('Mock log. mock')
-      expect(mockErrorLogger).not.toHaveBeenCalled()
-      expect(mockDebugLogger).not.toHaveBeenCalled()
-    })
-
-    it('Should call the error logger with the correct interpolated message', () => {
-      mockLogCode.level = 'error'
-      log(mockLogCode, messageOptions)
-      expect(mockErrorLogger).toHaveBeenCalledWith('Mock log. mock')
-    })
-
-    it('Should call the debug logger with the correct interpolated message', () => {
-      mockLogCode.level = 'debug'
-      log(mockLogCode, messageOptions)
-      expect(mockDebugLogger).toHaveBeenCalledWith('Mock log. mock')
-    })
-
-    it('Should call the debug logger with multiple interpolated values', () => {
-      const mockLogCode = {
-        level: 'info',
-        messageFunc: () =>
-          `interpolated-string ${messageOptions.mock} with two values ${messageOptions.mockAnother}`
-      }
-      const messageOptions = { mock: 'mockOne', mockAnother: 'mockTwo' }
-
-      log(mockLogCode, messageOptions)
-
-      expect(mockInfoLogger).toHaveBeenCalledWith(
-        'interpolated-string mockOne with two values mockTwo'
-      )
-    })
-
-    it('Should call a named logger with nested interpolated values', () => {
-      const mockLogCode = {
-        level: 'info',
-        messageFunc: () => {
-          return `interpolated-string ${messageOptions.mock.subMockOne}, and ${messageOptions.mock.subMockTwo}, and ${messageOptions.mockAnother}`
-        }
-      }
-      const messageOptions = {
-        mock: { subMockOne: 'mockOne', subMockTwo: 'mockTwo' },
-        mockAnother: 'mockThree'
-      }
-
-      log(mockLogCode, messageOptions)
-
-      expect(mockInfoLogger).toHaveBeenCalledWith(
-        'interpolated-string mockOne, and mockTwo, and mockThree'
-      )
-    })
-
-    it('Should call a named logger with the correct non-interpolated message', () => {
-      const mockLogCode = {
-        level: 'info',
-        messageFunc: () => 'Mock info log'
-      }
-
-      log(mockLogCode)
-
-      expect(mockInfoLogger).toHaveBeenCalledWith('Mock info log')
-    })
+    expect(mockInfoLogger).toHaveBeenCalledWith('Mock log. mock')
+    expect(mockErrorLogger).not.toHaveBeenCalled()
+    expect(mockDebugLogger).not.toHaveBeenCalled()
   })
 
-  describe('Validation Errors', () => {
-    const messageFunc = () => 'Mock log.'
+  it('Should call the error logger with the correct interpolated message', () => {
+    mockLogCode.level = 'error'
+    log(mockLogCode, messageOptions)
+    expect(mockErrorLogger).toHaveBeenCalledWith('Mock log. mock')
+  })
 
-    it('Should throw if logCode level is invalid', () => {
-      expect(() =>
-        log(
-          {
-            level: 'not-valid',
-            messageFunc
-          },
-          messageOptions
-        )
-      ).toThrow('Invalid log level')
-    })
+  it('Should call the debug logger with the correct interpolated message', () => {
+    mockLogCode.level = 'debug'
+    log(mockLogCode, messageOptions)
+    expect(mockDebugLogger).toHaveBeenCalledWith('Mock log. mock')
+  })
 
-    it('Should throw an error if logCode is not an object', () => {
-      expect(() => log(undefined, messageOptions)).toThrow(
-        'logCode must be a non-empty object'
-      )
-    })
+  it('Should call the debug logger with multiple interpolated values', () => {
+    const mockLogCode = {
+      level: 'info',
+      messageFunc: () =>
+        `interpolated-string ${messageOptions.mock} with two values ${messageOptions.mockAnother}`
+    }
+    const messageOptions = { mock: 'mockOne', mockAnother: 'mockTwo' }
 
-    it('Should throw an error if logCode is an empty object', () => {
-      expect(() => log({}, messageOptions)).toThrow(
-        'logCode must be a non-empty object'
-      )
-    })
+    log(mockLogCode, messageOptions)
 
-    it('Should throw an error if messageFunc is not an function', () => {
-      expect(() =>
-        log(
-          {
-            level: 'info',
-            messageFunc: 'not-a-function'
-          },
-          messageOptions
-        )
-      ).toThrow('logCode.messageFunc must be a function')
-    })
+    expect(mockInfoLogger).toHaveBeenCalledWith(
+      'interpolated-string mockOne with two values mockTwo'
+    )
+  })
+
+  it('Should call a named logger with nested interpolated values', () => {
+    const mockLogCode = {
+      level: 'info',
+      messageFunc: () => {
+        return `interpolated-string ${messageOptions.mock.subMockOne}, and ${messageOptions.mock.subMockTwo}, and ${messageOptions.mockAnother}`
+      }
+    }
+    const messageOptions = {
+      mock: { subMockOne: 'mockOne', subMockTwo: 'mockTwo' },
+      mockAnother: 'mockThree'
+    }
+
+    log(mockLogCode, messageOptions)
+
+    expect(mockInfoLogger).toHaveBeenCalledWith(
+      'interpolated-string mockOne, and mockTwo, and mockThree'
+    )
+  })
+
+  it('Should call a named logger with the correct non-interpolated message', () => {
+    const mockLogCode = {
+      level: 'info',
+      messageFunc: () => 'Mock info log'
+    }
+
+    log(mockLogCode)
+
+    expect(mockInfoLogger).toHaveBeenCalledWith('Mock info log')
   })
 })


### PR DESCRIPTION
At the moment we are validating the log code every time a log is made which is unnecessary overhead.

Validation should ideally happen once at startup when log codes are defined, rather than at runtime during every logging call.

Rather than having this done on every log invocation:

```
const log = (logCode, messageOptions) => {
  validateLogCode(logCode)
  getLoggerOfType(logCode.level)(logCode.messageFunc(messageOptions))
}
```

we should be doing this at startup instead:

```
const logCodes = {
  USER_LOGIN: { level: LogLevel.INFO, messageFunc: (opts) => `User ${opts.username} logged in.` },
  SYSTEM_ERROR: { level: LogLevel.ERROR, messageFunc: (opts) => `Critical error: ${opts.errorMessage}` }
}

// Validate all log codes once at startup
Object.values(logCodes).forEach(validateLogCode)

export default logCodes
```