### PR TITLE
TGC-557 - update to scoring config and added boolean types in validation

### DIFF
--- a/src/api/scoring/validation.js
+++ b/src/api/scoring/validation.js
@@ -23,7 +23,8 @@ export const scoringPayloadSchema = Joi.object({
         Joi.alternatives().try(
           Joi.string(),
           Joi.number(),
-          Joi.array().items(Joi.string(), Joi.number()).unique()
+          Joi.boolean(),
+          Joi.array().items(Joi.string(), Joi.number(), Joi.boolean()).unique()
         )
       )
       .required()

--- a/src/api/scoring/validation.test.js
+++ b/src/api/scoring/validation.test.js
@@ -90,7 +90,7 @@ describe('Scoring Payload Validation', () => {
 
         expect(error).toBeDefined()
         expect(error.details[0].message).toMatch(
-          /must be one of \[string, number, boolean, array\]/
+          /must be one of \[string, number, boolean, array]/
         )
       })
 
@@ -103,7 +103,7 @@ describe('Scoring Payload Validation', () => {
 
         expect(error).toBeDefined()
         expect(error.details[0].message).toMatch(
-          /"data.main.someKey\[1\]" does not match any of the allowed types/
+          /"data.main.someKey\[1]" does not match any of the allowed types/
         )
       })
 
@@ -114,7 +114,7 @@ describe('Scoring Payload Validation', () => {
         const { error } = scoringPayloadSchema.validate(invalidPayload)
         expect(error).toBeDefined()
         expect(error.details[0].message).toMatch(
-          /must be one of \[string, number, boolean, array\]/
+          /must be one of \[string, number, boolean, array]/
         )
       })
 
@@ -127,7 +127,7 @@ describe('Scoring Payload Validation', () => {
 
         expect(error).toBeDefined()
         expect(error.details[0].message).toMatch(
-          /"data.main.someKey\[1\]" contains a duplicate value/
+          /"data.main.someKey\[1]" contains a duplicate value/
         )
       })
     })

--- a/src/api/scoring/validation.test.js
+++ b/src/api/scoring/validation.test.js
@@ -90,7 +90,7 @@ describe('Scoring Payload Validation', () => {
 
         expect(error).toBeDefined()
         expect(error.details[0].message).toMatch(
-          /must be one of \[string, number, array\]/
+          /must be one of \[string, number, boolean, array\]/
         )
       })
 
@@ -114,7 +114,7 @@ describe('Scoring Payload Validation', () => {
         const { error } = scoringPayloadSchema.validate(invalidPayload)
         expect(error).toBeDefined()
         expect(error.details[0].message).toMatch(
-          /must be one of \[string, number, array\]/
+          /must be one of \[string, number, boolean, array\]/
         )
       })
 

--- a/src/config/grants/adding-value-grant-config.js
+++ b/src/config/grants/adding-value-grant-config.js
@@ -15,7 +15,7 @@ const addingValueGrantConfig = {
   questions: [
     {
       id: '/products-processed',
-      category: 'Products processed',
+      category: 'Produce processed',
       fundingPriorities: [
         'Create and expand processing capacity to provide more English-grown food for consumers to buy'
       ],
@@ -141,11 +141,11 @@ const addingValueGrantConfig = {
     }
   ],
   scoreBand: [
-    { name: ScoreBands.WEAK, minValue: 0, maxValue: 51 },
-    { name: ScoreBands.MEDIUM, minValue: 52, maxValue: 80 },
-    { name: ScoreBands.STRONG, minValue: 81, maxValue: 93 }
+    { name: ScoreBands.WEAK, minValue: 0, maxValue: 17 },
+    { name: ScoreBands.MEDIUM, minValue: 17, maxValue: 28 },
+    { name: ScoreBands.STRONG, minValue: 28, maxValue: 37 }
   ],
-  maxScore: 93,
+  maxScore: 37,
   eligibilityPercentageThreshold: 60
 }
 


### PR DESCRIPTION
- Modified scoring config to score the three questions in `adding-value` correctly as per spec
- DXT will now send us boolean types in `Record<data.main, string | boolean | number>`. This PR adds the boolean types to our validation and also removes some redundant escapes in test files.