### PR TITLE
complete test coverage

### DIFF
--- a/src/api/common/helpers/logging/logger-options.test.js
+++ b/src/api/common/helpers/logging/logger-options.test.js
@@ -1,0 +1,26 @@
+import { loggerOptions } from './logger-options.js'
+import { getTraceId } from '@defra/hapi-tracing'
+
+jest.mock('@defra/hapi-tracing')
+
+describe('Logger mixin()', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should return an empty object if no traceId is returned', () => {
+    getTraceId.mockReturnValueOnce(null)
+
+    const mixin = loggerOptions.mixin()
+
+    expect(mixin).toEqual({})
+  })
+
+  it('should include traceId in the mixin if getTraceId returns a trace ID', () => {
+    getTraceId.mockReturnValueOnce('some-trace-id')
+
+    const mixin = loggerOptions.mixin()
+
+    expect(mixin).toEqual({ trace: { id: 'some-trace-id' } })
+  })
+})

--- a/src/api/logging/log-code-validator.test.js
+++ b/src/api/logging/log-code-validator.test.js
@@ -1,0 +1,61 @@
+import { validateLogCode } from './log-code-validator.js'
+
+describe('validateLogCode', () => {
+  it('should not throw an error for a valid log code', () => {
+    const validLogCode = {
+      level: 'info',
+      messageFunc: () => 'Test message'
+    }
+
+    expect(() => validateLogCode(validLogCode)).not.toThrow()
+  })
+
+  it('should throw an error if logCode is not an object', () => {
+    expect(() => validateLogCode(null)).toThrow(
+      'logCode must be a non-empty object'
+    )
+    expect(() => validateLogCode(undefined)).toThrow(
+      'logCode must be a non-empty object'
+    )
+    expect(() => validateLogCode('string')).toThrow(
+      'logCode must be a non-empty object'
+    )
+    expect(() => validateLogCode({})).toThrow(
+      'logCode must be a non-empty object'
+    )
+  })
+
+  it('should throw an error if elements are missing', () => {
+    expect(() =>
+      validateLogCode({
+        messageFunc: () => 'Test message'
+      })
+    ).toThrow('Invalid log level')
+
+    expect(() =>
+      validateLogCode({
+        level: 'info'
+      })
+    ).toThrow('logCode.messageFunc must be a function')
+  })
+
+  it('should throw an error if logCode.level is not a valid value', () => {
+    const invalidLogCode = {
+      level: 'invalid',
+      messageFunc: () => 'Test message'
+    }
+
+    expect(() => validateLogCode(invalidLogCode)).toThrow('Invalid log level')
+  })
+
+  it('should throw an error if logCode.messageFunc is not a function', () => {
+    const invalidLogCode = {
+      level: 'info',
+      messageFunc: 'not-a-function'
+    }
+
+    expect(() => validateLogCode(invalidLogCode)).toThrow(
+      'logCode.messageFunc must be a function'
+    )
+  })
+})

--- a/src/api/scoring/mapper/map-to-final-result.js
+++ b/src/api/scoring/mapper/map-to-final-result.js
@@ -15,10 +15,10 @@ function mapToFinalResult(scoringConfig, rawScores) {
   // Calculate max score by summing up the highest possible score for each question
   const maxScore = scoringConfig.maxScore
   const percentage = maxScore > 0 ? (score / maxScore) * 100 : 0
-  const scoreBand =
-    scoringConfig.scoreBand.find(
-      (band) => score >= band.minValue && score <= band.maxValue
-    ).name ?? null
+  const foundBand = scoringConfig.scoreBand.find(
+    (band) => score >= band.minValue && score <= band.maxValue
+  )
+  const scoreBand = foundBand ? foundBand.name : null
 
   return {
     answers: rawScores,

--- a/src/api/scoring/mapper/map-to-final-result.test.js
+++ b/src/api/scoring/mapper/map-to-final-result.test.js
@@ -124,4 +124,22 @@ describe('mapToFinalResult', () => {
       'rawScores must be an array'
     )
   })
+
+  it('should return null for scoreBand if no matching band is found', () => {
+    const scoringConfigWithNoMatchingBand = {
+      ...scoringConfig,
+      scoreBand: [
+        { name: ScoreBands.WEAK, minValue: 0, maxValue: 1 },
+        { name: ScoreBands.MEDIUM, minValue: 2, maxValue: 3 }
+      ]
+    }
+
+    const rawScores = [
+      { questionId: 'q1', score: { value: 5, band: ScoreBands.STRONG } }
+    ]
+
+    const result = mapToFinalResult(scoringConfigWithNoMatchingBand, rawScores)
+
+    expect(result.scoreBand).toBeNull()
+  })
 })

--- a/src/config/grants/adding-value-grant-config.js
+++ b/src/config/grants/adding-value-grant-config.js
@@ -151,6 +151,7 @@ const addingValueGrantConfig = {
 
 const { error, value } = scoringConfigSchema.validate(addingValueGrantConfig)
 
+// istanbul ignore next
 if (error) {
   throw new Error(`Validation failed: ${error.message}`)
 }

--- a/src/config/grants/example-grant-config.js
+++ b/src/config/grants/example-grant-config.js
@@ -64,6 +64,7 @@ const exampleGrantConfig = {
 
 const { error, value } = scoringConfigSchema.validate(exampleGrantConfig)
 
+// istanbul ignore next
 if (error) {
   throw new Error(`Validation failed: ${error.message}`)
 }

--- a/src/config/scoring-config.test.js
+++ b/src/config/scoring-config.test.js
@@ -1,0 +1,33 @@
+import { getScoringConfig } from './scoring-config.js'
+
+const exampleGrantConfigMock = { mockKey: 'exampleGrantConfigMock' }
+const addingValueGrantConfigMock = { mockKey: 'addingValueGrantConfigMock' }
+
+jest.mock('./grants/example-grant-config.js', () => ({
+  exampleGrantConfig: exampleGrantConfigMock
+}))
+
+jest.mock('./grants/adding-value-grant-config.js', () => ({
+  addingValueGrantConfig: addingValueGrantConfigMock
+}))
+
+describe('getScoringConfig', () => {
+  test('should return the mocked config for "example-grant"', () => {
+    expect(JSON.stringify(getScoringConfig('example-grant'))).toBe(
+      JSON.stringify(exampleGrantConfigMock)
+    )
+  })
+
+  test('should return the mocked config for "adding-value"', () => {
+    expect(JSON.stringify(getScoringConfig('adding-value'))).toBe(
+      JSON.stringify(addingValueGrantConfigMock)
+    )
+  })
+
+  test('should return null for an unknown variables', () => {
+    expect(getScoringConfig('unknown-grant')).toBeNull()
+    expect(getScoringConfig('')).toBeNull()
+    expect(getScoringConfig(undefined)).toBeNull()
+    expect(getScoringConfig(null)).toBeNull()
+  })
+})

--- a/src/services/scoring/methods/multi-score.js
+++ b/src/services/scoring/methods/multi-score.js
@@ -28,10 +28,11 @@ function multiScore(questionScoringConfig, userAnswers) {
 
   // Sum up all the valid scores
   const value = scores.reduce((total, score) => total + score, 0)
-  const band =
-    questionScoringConfig.scoreBand.find(
-      (scoreBand) => value >= scoreBand.minValue && value <= scoreBand.maxValue
-    ).name ?? null
+  const foundBand = questionScoringConfig.scoreBand.find(
+    (scoreBand) => value >= scoreBand.minValue && value <= scoreBand.maxValue
+  )
+  const band = foundBand ? foundBand.name : null
+
   return { value, band }
 }
 

--- a/src/services/scoring/methods/multi-score.test.js
+++ b/src/services/scoring/methods/multi-score.test.js
@@ -59,4 +59,24 @@ describe('multiScore', () => {
       multiScore(questionConfig, ['F']) // Invalid answer
     }).toThrow('Answer "F" not found in question: multiAnswer.')
   })
+
+  it('should return null for band if no matching band is found', () => {
+    const questionConfigWithNoMatchingBand = {
+      ...questionConfig,
+      scoreBand: [
+        { name: ScoreBands.WEAK, minValue: 0, maxValue: 3 },
+        { name: ScoreBands.MEDIUM, minValue: 4, maxValue: 6 }
+      ]
+    }
+
+    const result = multiScore(questionConfigWithNoMatchingBand, [
+      'A',
+      'B',
+      'C',
+      'D'
+    ])
+
+    expect(result.value).toBe(12)
+    expect(result.band).toBeNull()
+  })
 })

--- a/src/services/scoring/methods/single-score.js
+++ b/src/services/scoring/methods/single-score.js
@@ -23,10 +23,10 @@ function singleScore(questionScoringConfig, userAnswers) {
   }
 
   const value = matchingAnswer.score
-  const band =
-    questionScoringConfig.scoreBand.find(
-      (band) => value >= band.minValue && value <= band.maxValue
-    ).name ?? null
+  const foundBand = questionScoringConfig.scoreBand.find(
+    (scoreBand) => value >= scoreBand.minValue && value <= scoreBand.maxValue
+  )
+  const band = foundBand ? foundBand.name : null
   return { value, band }
 }
 

--- a/src/services/scoring/methods/single-score.test.js
+++ b/src/services/scoring/methods/single-score.test.js
@@ -52,4 +52,19 @@ describe('singleScore', () => {
       singleScore(questionConfig, ['C'])
     }).toThrow('Answer "C" not found in question: singleAnswer.')
   })
+
+  it('should return null for band if no matching band is found', () => {
+    const questionConfigWithNoMatchingBand = {
+      ...questionConfig,
+      scoreBand: [
+        { name: ScoreBands.WEAK, minValue: 0, maxValue: 3 },
+        { name: ScoreBands.MEDIUM, minValue: 4, maxValue: 6 }
+      ]
+    }
+
+    const result = singleScore(questionConfigWithNoMatchingBand, ['B'])
+
+    expect(result.value).toBe(8)
+    expect(result.band).toBeNull()
+  })
 })


### PR DESCRIPTION
logger-options.test.js, log-code-validator.test.js, and scoring-config.test.js required adding new test modules.

adding-value-grant-config.js & example-grant-config.js had one line of missed coverage. Decided to omit those lines as unit testing code that is initiated on module loading (module scope) is difficult and would be a lot for single lines of code.

map-to-final-result.js, multi-score, and single-score had had a flaw which meant that there would have been an uncaught error because .find() returns undefined when no matching score band is found, and trying to access .name on undefined causes the error. Their respective tests have been updated to test the more robust code.