### PR TITLE
Implemented matrix scoring

### DIFF
--- a/src/config/grants/adding-value-grant-config.js
+++ b/src/config/grants/adding-value-grant-config.js
@@ -1,5 +1,6 @@
 import singleScore from '~/src/services/scoring/methods/single-score.js'
 import multiScore from '~/src/services/scoring/methods/multi-score.js'
+import matrixScore from '~/src/services/scoring/methods/matrix-score.js'
 import { ScoreBands } from '../score-bands.js'
 import { scoringConfigSchema } from '../scoring-config-schema.js'
 
@@ -19,15 +20,72 @@ const addingValueGrantConfig = {
       fundingPriorities: [
         'Create and expand processing capacity to provide more English-grown food for consumers to buy'
       ],
-      scoreMethod: singleScore,
+      scoreMethod: matrixScore,
+      scoreDependency: 'addingValue',
       answers: [
-        { answer: 'products-processed-A1', score: 7 },
-        { answer: 'products-processed-A2', score: 6 },
-        { answer: 'products-processed-A3', score: 5 },
-        { answer: 'products-processed-A4', score: 4 },
-        { answer: 'products-processed-A5', score: 3 },
-        { answer: 'products-processed-A6', score: 2 },
-        { answer: 'products-processed-A7', score: 1 }
+        {
+          answer: 'products-processed-A1',
+          score: {
+            'adding-value-A1': 24,
+            'adding-value-A2': 18,
+            'adding-value-A3': 9,
+            'adding-value-A4': 3
+          }
+        },
+        {
+          answer: 'products-processed-A2',
+          score: {
+            'adding-value-A1': 30,
+            'adding-value-A2': 21,
+            'adding-value-A3': 12,
+            'adding-value-A4': 3
+          }
+        },
+        {
+          answer: 'products-processed-A3',
+          score: {
+            'adding-value-A1': 24,
+            'adding-value-A2': 18,
+            'adding-value-A3': 9,
+            'adding-value-A4': 3
+          }
+        },
+        {
+          answer: 'products-processed-A4',
+          score: {
+            'adding-value-A1': 0,
+            'adding-value-A2': 0,
+            'adding-value-A3': 0,
+            'adding-value-A4': 0
+          }
+        },
+        {
+          answer: 'products-processed-A5',
+          score: {
+            'adding-value-A1': 15,
+            'adding-value-A2': 9,
+            'adding-value-A3': 3,
+            'adding-value-A4': 0
+          }
+        },
+        {
+          answer: 'products-processed-A6',
+          score: {
+            'adding-value-A1': 18,
+            'adding-value-A2': 12,
+            'adding-value-A3': 6,
+            'adding-value-A4': 0
+          }
+        },
+        {
+          answer: 'products-processed-A7',
+          score: {
+            'adding-value-A1': 15,
+            'adding-value-A2': 9,
+            'adding-value-A3': 3,
+            'adding-value-A4': 0
+          }
+        }
       ],
       scoreBand: [
         { name: ScoreBands.WEAK, minValue: 0, maxValue: 2 },
@@ -43,13 +101,8 @@ const addingValueGrantConfig = {
         IMPROVE_PROCESSING_AND_SUPPLY_CHAINS,
         GROW_YOUR_BUSINESS
       ],
-      scoreMethod: singleScore,
-      answers: [
-        { answer: 'adding-value-A1', score: 9 },
-        { answer: 'adding-value-A2', score: 7 },
-        { answer: 'adding-value-A3', score: 5 },
-        { answer: 'adding-value-A4', score: 3 }
-      ],
+      scoreMethod: () => undefined,
+      isDependency: true,
       scoreBand: [
         { name: ScoreBands.WEAK, minValue: 0, maxValue: 5 },
         { name: ScoreBands.MEDIUM, minValue: 6, maxValue: 7 },

--- a/src/config/scoring-config-schema.js
+++ b/src/config/scoring-config-schema.js
@@ -5,7 +5,10 @@ const answersSchema = Joi.array()
   .items(
     Joi.object({
       answer: Joi.string().required(),
-      score: Joi.number().allow(null) // Allow numbers or null
+      score: Joi.alternatives().try(
+        Joi.number().allow(null),
+        Joi.object().pattern(Joi.string(), Joi.number().allow(null))
+      )
     })
   )
   .required()
@@ -28,8 +31,14 @@ const questionsSchema = Joi.array()
       id: Joi.string().required(),
       category: Joi.string().required(),
       fundingPriorities: Joi.array().items(Joi.string()).optional(),
+      isDependency: Joi.boolean().optional(),
+      scoreDependency: Joi.string().optional(),
       scoreMethod: Joi.function().required(),
-      answers: answersSchema,
+      answers: Joi.alternatives().conditional('isDependency', {
+        is: true,
+        then: Joi.optional(),
+        otherwise: answersSchema
+      }),
       scoreBand: scoreBandSchema,
       maxScore: Joi.number().required()
     })

--- a/src/config/scoring-types.js
+++ b/src/config/scoring-types.js
@@ -1,7 +1,7 @@
 /**
  * @typedef {object} Answer
  * @property {string} answer - The answer text.
- * @property {number|null} score - The score associated with the answer, or null if no score applies.
+ * @property {number|null|Record<string, number>} score - The score associated with the answer, or null if no score applies.
  */
 
 /**
@@ -16,7 +16,9 @@
  * @property {string} category - The category of the question.
  * @property {string[]} fundingPriorities - An optional array of funding priorities related to the question.
  * @property {Function} scoreMethod - The scoring function to calculate the score for the question.
- * @property {Answer[]} answers - An array of possible answers for the question.
+ * @property {string|undefined} scoreDependency - The ID of the question that the score depends on.
+ * @property {boolean|undefined} isDependent - A flag indicating if the question is dependent on another question.
+ * @property {Answer[]|undefined} answers - An array of possible answers for the question.
  * @property {number} maxScore - Max score
  * @property {ScoreBand[]} scoreBand - An array of score bands for the question.
  */

--- a/src/services/scoring/methods/matrix-score.js
+++ b/src/services/scoring/methods/matrix-score.js
@@ -1,5 +1,13 @@
 import singleScore from '~/src/services/scoring/methods/single-score.js'
 
+/**
+ * Calculates and returns the score for a given set of user answers based on the question scoring configuration
+ * and dependent user answers.
+ * @param {object} questionScoringConfig - The configuration object for scoring, including answers and dependency mappings.
+ * @param {Array} userAnswers - The list of answers provided by the user.
+ * @param {object} dependentUserAnswers - An object containing dependent answers referenced during score calculation.
+ * @returns {{value: number, band: string}} The calculated score object based on the provided answers and scoring configuration.
+ */
 function matrixScore(questionScoringConfig, userAnswers, dependentUserAnswers) {
   const dependentAnswer =
     dependentUserAnswers[questionScoringConfig.scoreDependency][0]

--- a/src/services/scoring/methods/matrix-score.js
+++ b/src/services/scoring/methods/matrix-score.js
@@ -1,25 +1,26 @@
-import singleScore from '~/src/services/scoring/methods/single-score.js'
+import singleScore from './single-score.js'
 
 /**
  * Calculates and returns the score for a given set of user answers based on the question scoring configuration
  * and dependent user answers.
- * @param {object} questionScoringConfig - The configuration object for scoring, including answers and dependency mappings.
+ * @param {object} scoringConfig - The configuration object for scoring, including answers and dependency mappings.
  * @param {Array} userAnswers - The list of answers provided by the user.
  * @param {object} dependentUserAnswers - An object containing dependent answers referenced during score calculation.
  * @returns {{value: number, band: string}} The calculated score object based on the provided answers and scoring configuration.
  */
-function matrixScore(questionScoringConfig, userAnswers, dependentUserAnswers) {
-  const dependentAnswer =
-    dependentUserAnswers[questionScoringConfig.scoreDependency][0]
-  const modifiedScoring = questionScoringConfig.answers.map(
+function matrixScore(scoringConfig, userAnswers, dependentUserAnswers) {
+  const dependencyScoringConfig =
+    dependentUserAnswers[scoringConfig.scoreDependency][0]
+
+  const dependencyModifiedScores = scoringConfig.answers.map(
     ({ answer, score }) => ({
       answer,
-      score: score[dependentAnswer]
+      score: score[dependencyScoringConfig]
     })
   )
 
   return singleScore(
-    { ...questionScoringConfig, answers: [...modifiedScoring] },
+    { ...scoringConfig, answers: dependencyModifiedScores },
     userAnswers
   )
 }

--- a/src/services/scoring/methods/matrix-score.js
+++ b/src/services/scoring/methods/matrix-score.js
@@ -1,0 +1,19 @@
+import singleScore from '~/src/services/scoring/methods/single-score.js'
+
+function matrixScore(questionScoringConfig, userAnswers, dependentUserAnswers) {
+  const dependentAnswer =
+    dependentUserAnswers[questionScoringConfig.scoreDependency][0]
+  const modifiedScoring = questionScoringConfig.answers.map(
+    ({ answer, score }) => ({
+      answer,
+      score: score[dependentAnswer]
+    })
+  )
+
+  return singleScore(
+    { ...questionScoringConfig, answers: [...modifiedScoring] },
+    userAnswers
+  )
+}
+
+export default matrixScore

--- a/src/services/scoring/methods/matrix-score.test.js
+++ b/src/services/scoring/methods/matrix-score.test.js
@@ -38,7 +38,13 @@ const questionConfig = [
   },
   {
     id: 'dependentQuestion',
-    isDependency: true
+    isDependency: true,
+    maxScore: 8,
+    scoreBand: [
+      { name: ScoreBands.WEAK, minValue: 0, maxValue: 2 },
+      { name: ScoreBands.MEDIUM, minValue: 3, maxValue: 5 },
+      { name: ScoreBands.STRONG, minValue: 6, maxValue: 8 }
+    ]
   }
 ]
 

--- a/src/services/scoring/methods/matrix-score.test.js
+++ b/src/services/scoring/methods/matrix-score.test.js
@@ -1,0 +1,81 @@
+import { ScoreBands } from '../../../config/score-bands.js'
+import multiScore from './multi-score.js'
+import matrixScore from '~/src/services/scoring/methods/matrix-score.js' // adjust path as needed
+
+/**
+ * Question config.
+ * @type {import("../../../config/scoring-types.js").Question}
+ */
+const questionConfig = [
+  {
+    id: 'matrixScore',
+    scoreDependency: 'matrixDependency',
+    answers: [
+      { answer: 'A', score: { A: 1, B: 2, C: 3, D: 4 } },
+      { answer: 'B', score: { A: 2, B: 4, C: 6, D: 8 } }
+    ],
+    maxScore: 8,
+    scoreBand: [
+      { name: ScoreBands.WEAK, minValue: 0, maxValue: 2 },
+      { name: ScoreBands.MEDIUM, minValue: 3, maxValue: 5 },
+      { name: ScoreBands.STRONG, minValue: 6, maxValue: 8 }
+    ]
+  },
+  {
+    id: 'matrixDependency',
+    isDependency: true
+  }
+]
+
+describe('matrixScore', () => {
+  it.each([
+    {
+      answer: 'A',
+      dependentAnswer: 'A',
+      expectedScore: 1
+    },
+    {
+      answer: 'A',
+      dependentAnswer: 'B',
+      expectedScore: 2
+    },
+    {
+      answer: 'A',
+      dependentAnswer: 'C',
+      expectedScore: 3
+    },
+    {
+      answer: 'A',
+      dependentAnswer: 'D',
+      expectedScore: 4
+    },
+    {
+      answer: 'B',
+      dependentAnswer: 'A',
+      expectedScore: 2
+    },
+    {
+      answer: 'B',
+      dependentAnswer: 'B',
+      expectedScore: 4
+    },
+    {
+      answer: 'B',
+      dependentAnswer: 'C',
+      expectedScore: 6
+    },
+    {
+      answer: 'B',
+      dependentAnswer: 'D',
+      expectedScore: 8
+    }
+  ])(
+    `should return correct matrix score result using answers $answer and $dependentAnswer`,
+    ({ answer, dependentAnswer, expectedScore }) => {
+      const result = matrixScore(questionConfig[0], [answer], {
+        matrixDependency: [dependentAnswer]
+      })
+      expect(result.value).toBe(expectedScore)
+    }
+  )
+})

--- a/src/services/scoring/methods/matrix-score.test.js
+++ b/src/services/scoring/methods/matrix-score.test.js
@@ -3,15 +3,31 @@ import matrixScore from './matrix-score.js' // adjust path as needed
 
 /**
  * Question config.
- * @type {import("../../../config/scoring-types.js").Question}
+ * @type {import("~/src/config/scoring-types.js").Question[]} questionConfig
  */
 const questionConfig = [
   {
     id: 'matrixScore',
     scoreDependency: 'matrixDependency',
     answers: [
-      { answer: 'A', score: { A: 1, B: 2, C: 3, D: 4 } },
-      { answer: 'B', score: { A: 2, B: 4, C: 6, D: 8 } }
+      {
+        answer: 'matrixScoreA',
+        score: {
+          dependentQuestionA: 1,
+          dependentQuestionB: 2,
+          dependentQuestionC: 3,
+          dependentQuestionD: 4
+        }
+      },
+      {
+        answer: 'matrixScoreB',
+        score: {
+          dependentQuestionA: 2,
+          dependentQuestionB: 4,
+          dependentQuestionC: 6,
+          dependentQuestionD: 8
+        }
+      }
     ],
     maxScore: 8,
     scoreBand: [
@@ -21,7 +37,7 @@ const questionConfig = [
     ]
   },
   {
-    id: 'matrixDependency',
+    id: 'dependentQuestion',
     isDependency: true
   }
 ]
@@ -29,43 +45,43 @@ const questionConfig = [
 describe('matrixScore', () => {
   it.each([
     {
-      answer: 'A',
-      dependentAnswer: 'A',
+      answer: 'matrixScoreA',
+      dependentAnswer: 'dependentQuestionA',
       expectedScore: 1
     },
     {
-      answer: 'A',
-      dependentAnswer: 'B',
+      answer: 'matrixScoreA',
+      dependentAnswer: 'dependentQuestionB',
       expectedScore: 2
     },
     {
-      answer: 'A',
-      dependentAnswer: 'C',
+      answer: 'matrixScoreA',
+      dependentAnswer: 'dependentQuestionC',
       expectedScore: 3
     },
     {
-      answer: 'A',
-      dependentAnswer: 'D',
+      answer: 'matrixScoreA',
+      dependentAnswer: 'dependentQuestionD',
       expectedScore: 4
     },
     {
-      answer: 'B',
-      dependentAnswer: 'A',
+      answer: 'matrixScoreB',
+      dependentAnswer: 'dependentQuestionA',
       expectedScore: 2
     },
     {
-      answer: 'B',
-      dependentAnswer: 'B',
+      answer: 'matrixScoreB',
+      dependentAnswer: 'dependentQuestionB',
       expectedScore: 4
     },
     {
-      answer: 'B',
-      dependentAnswer: 'C',
+      answer: 'matrixScoreB',
+      dependentAnswer: 'dependentQuestionC',
       expectedScore: 6
     },
     {
-      answer: 'B',
-      dependentAnswer: 'D',
+      answer: 'matrixScoreB',
+      dependentAnswer: 'dependentQuestionD',
       expectedScore: 8
     }
   ])(

--- a/src/services/scoring/methods/matrix-score.test.js
+++ b/src/services/scoring/methods/matrix-score.test.js
@@ -1,6 +1,5 @@
 import { ScoreBands } from '../../../config/score-bands.js'
-import multiScore from './multi-score.js'
-import matrixScore from '~/src/services/scoring/methods/matrix-score.js' // adjust path as needed
+import matrixScore from './matrix-score.js' // adjust path as needed
 
 /**
  * Question config.

--- a/src/services/scoring/methods/multi-score.js
+++ b/src/services/scoring/methods/multi-score.js
@@ -8,17 +8,25 @@
  */
 function multiScore(questionScoringConfig, userAnswers) {
   const scores = userAnswers.map((userAnswer) => {
-    const matchingAnswer = questionScoringConfig.answers.find(
-      (answer) => answer.answer === userAnswer
+    const matchingScoreConfig = questionScoringConfig.answers.find(
+      (scoringComponent) => scoringComponent.answer === userAnswer
     )
 
-    if (!matchingAnswer) {
+    if (!matchingScoreConfig) {
       throw new Error(
         `Answer "${userAnswer}" not found in question: ${questionScoringConfig.id}.`
       )
     }
 
-    return matchingAnswer.score
+    // This is needed to allow "None of the above" to be handled correctly but also to ensure that
+    // the types are correct for the following scores.reduce function. Ideally we would like
+    // to throw an error here to catch invalid scoring configurations passed in to multiScore
+    if (typeof matchingScoreConfig.score !== 'number') {
+      matchingScoreConfig.score = 0
+    }
+
+    /** @type {number} */
+    return matchingScoreConfig.score
   })
 
   // Sum up all the valid scores

--- a/src/services/scoring/methods/multi-score.js
+++ b/src/services/scoring/methods/multi-score.js
@@ -7,11 +7,6 @@
  * @throws {Error} Throws if none of the `userAnswers` are found in the scoring rules.
  */
 function multiScore(questionScoringConfig, userAnswers) {
-  // @todo this code is nasty, if it remains in the repo it needs to be moved to middleware. Ideally we should never need this once DXT has completed their work.
-  if (userAnswers.length === 1) {
-    userAnswers = [...new Set(userAnswers[0].split(','))]
-  }
-
   const scores = userAnswers.map((userAnswer) => {
     const matchingAnswer = questionScoringConfig.answers.find(
       (answer) => answer.answer === userAnswer

--- a/src/services/scoring/score.js
+++ b/src/services/scoring/score.js
@@ -68,8 +68,6 @@ function scoreAnswers(filteredAnswers, questionMap) {
         ([dependencyId]) => dependencyId === question.scoreDependency
       )[1]
 
-      // dependentUserAnswers.adding-value = 'adding-value-A1'
-
       if (dependentUserAnswers[question.scoreDependency] === undefined) {
         throw new Error(
           `Answer for question "${question.scoreDependency}" not found, and is a dependency of "${question.id}".`

--- a/src/services/scoring/score.js
+++ b/src/services/scoring/score.js
@@ -25,9 +25,9 @@ function findMissingQuestions(filteredAnswers, requiredQuestionIds) {
 
 /**
  * Splits deferred answers from answers to score.
- * @param {Array} filteredAnswers
- * @param {Map<string, Object>} questionMap
- * @returns {Array, Array} An array of deferred answers and an array of answers to score.
+ * @param {Array} filteredAnswers - User answers after filtering.
+ * @param {Map<string, object>} questionMap - Map of all questions
+ * @returns {[Array, Array]} An array of deferred answers and an array of answers to score.
  */
 function splitDeferredAnswers(filteredAnswers, questionMap) {
   return filteredAnswers.reduce(
@@ -65,7 +65,7 @@ function scoreAnswers(filteredAnswers, questionMap) {
 
     if (question.scoreDependency) {
       dependentUserAnswers[question.scoreDependency] = deferredAnswers.find(
-        ([questionId]) => questionId === question.scoreDependency
+        ([dependencyId]) => dependencyId === question.scoreDependency
       )[1]
 
       // dependentUserAnswers.adding-value = 'adding-value-A1'
@@ -79,7 +79,7 @@ function scoreAnswers(filteredAnswers, questionMap) {
 
     // Ensure responses are always an array
     const responses = Array.isArray(answers) ? answers : [answers]
-    const score = question.scoreMethod(
+    const answersScored = question.scoreMethod(
       question,
       responses,
       dependentUserAnswers
@@ -92,7 +92,7 @@ function scoreAnswers(filteredAnswers, questionMap) {
         questionId: deferred.id,
         category: deferred.category,
         fundingPriorities: deferred.fundingPriorities,
-        score
+        score: answersScored
       })
     }
 
@@ -100,7 +100,7 @@ function scoreAnswers(filteredAnswers, questionMap) {
       questionId,
       category: question.category,
       fundingPriorities: question.fundingPriorities,
-      score: question.scoreMethod(question, responses, dependentUserAnswers)
+      score: answersScored
     }
   })
 

--- a/src/services/scoring/score.test.js
+++ b/src/services/scoring/score.test.js
@@ -50,8 +50,24 @@ describe('score function', () => {
       category: 'Category 2',
       fundingPriorities: ['Priority B', 'Priority C'],
       answers: [
-        { answer: 'A', score: { A: 1, B: 2, C: 3, D: 4 } },
-        { answer: 'B', score: { A: 2, B: 4, C: 6, D: 8 } }
+        {
+          answer: 'matrixScoreA',
+          score: {
+            matrixDependencyA: 1,
+            matrixDependencyB: 2,
+            matrixDependencyC: 3,
+            matrixDependencyD: 4
+          }
+        },
+        {
+          answer: 'matrixScoreB',
+          score: {
+            matrixDependencyA: 2,
+            matrixDependencyB: 4,
+            matrixDependencyC: 6,
+            matrixDependencyD: 8
+          }
+        }
       ],
       maxScore: 8,
       scoreBand: [
@@ -138,7 +154,10 @@ describe('score function', () => {
   })
 
   it('returns correct scores for valid matrixScoring question', () => {
-    const answers = { matrixAnswer: ['A'], matrixDependency: ['A'] }
+    const answers = {
+      matrixAnswer: ['matrixScoreA'],
+      matrixDependency: ['matrixDependencyA']
+    }
     const mockConfig = mockScoringConfig('matrixAnswer', 'matrixDependency')
     const result = score(mockConfig)(answers)
     expect(result).toHaveLength(2)
@@ -160,50 +179,50 @@ describe('score function', () => {
 
   it.each([
     {
-      answer: 'A',
-      dependentAnswer: 'A',
+      answer: 'matrixScoreA',
+      dependentAnswer: 'matrixDependencyA',
       expectedScore: 1,
       expectedBand: ScoreBands.WEAK
     },
     {
-      answer: 'A',
-      dependentAnswer: 'B',
+      answer: 'matrixScoreA',
+      dependentAnswer: 'matrixDependencyB',
       expectedScore: 2,
       expectedBand: ScoreBands.WEAK
     },
     {
-      answer: 'A',
-      dependentAnswer: 'C',
+      answer: 'matrixScoreA',
+      dependentAnswer: 'matrixDependencyC',
       expectedScore: 3,
       expectedBand: ScoreBands.MEDIUM
     },
     {
-      answer: 'A',
-      dependentAnswer: 'D',
+      answer: 'matrixScoreA',
+      dependentAnswer: 'matrixDependencyD',
       expectedScore: 4,
       expectedBand: ScoreBands.MEDIUM
     },
     {
-      answer: 'B',
-      dependentAnswer: 'A',
+      answer: 'matrixScoreB',
+      dependentAnswer: 'matrixDependencyA',
       expectedScore: 2,
       expectedBand: ScoreBands.WEAK
     },
     {
-      answer: 'B',
-      dependentAnswer: 'B',
+      answer: 'matrixScoreB',
+      dependentAnswer: 'matrixDependencyB',
       expectedScore: 4,
       expectedBand: ScoreBands.MEDIUM
     },
     {
-      answer: 'B',
-      dependentAnswer: 'C',
+      answer: 'matrixScoreB',
+      dependentAnswer: 'matrixDependencyC',
       expectedScore: 6,
       expectedBand: ScoreBands.STRONG
     },
     {
-      answer: 'B',
-      dependentAnswer: 'D',
+      answer: 'matrixScoreB',
+      dependentAnswer: 'matrixDependencyD',
       expectedScore: 8,
       expectedBand: ScoreBands.STRONG
     }
@@ -215,13 +234,13 @@ describe('score function', () => {
         matrixDependency: [dependentAnswer]
       }
       const mockConfig = mockScoringConfig('matrixAnswer', 'matrixDependency')
-      const sut = score(mockConfig)(answers)
-      expect(sut).toHaveLength(2)
+      const result = score(mockConfig)(answers)
+      expect(result).toHaveLength(2)
       // Ensure that both questions receive the same score and band
       // The band is the important part, for the dependent question the score is irrelevant
-      sut.forEach((result) => {
-        expect(result.score.value).toBe(expectedScore)
-        expect(result.score.band).toBe(expectedBand)
+      result.forEach((matrixAnswer) => {
+        expect(matrixAnswer.score.value).toBe(expectedScore)
+        expect(matrixAnswer.score.band).toBe(expectedBand)
       })
     }
   )

--- a/src/services/scoring/score.test.js
+++ b/src/services/scoring/score.test.js
@@ -1,7 +1,7 @@
 import score from './score.js'
 import multiScore from './methods/multi-score.js'
 import singleScore from './methods/single-score.js'
-import matrixScore from '~/src/services/scoring/methods/matrix-score.js'
+import matrixScore from './methods/matrix-score.js'
 import { ScoreBands } from '~/src/config/score-bands.js'
 
 describe('score function', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "target": "ES2021",
+    "lib": ["es2021"],
     "allowJs": true,
     "checkJs": false,
     "module": "NodeNext",


### PR DESCRIPTION
This PR implements the capability to score two questions as one in a matrix.

This requires the two questions to be linked in configuration. One question contains all the scoring data and *must* contain a `scoreDependency` key containing the ID of the linked question.

The dependent question must contain an `isDependency: true` key/value pair and does not require an `answers` key, as this data is already contained in the linked question.

The master question is scored, and the results are duplicated into the paired questions' result set.